### PR TITLE
feat: allow configuration of nodeSelector, affinity, and tolerations

### DIFF
--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -16,6 +16,18 @@ spec:
       labels:
         app.kubernetes.io/name: "{{ .Release.Name }}"
     spec:
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
       serviceAccountName: {{ .Release.Name }}
       containers:
       - name: {{ .Chart.Name }}

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -17,6 +17,12 @@ gateway:
 podMonitor:
   additionalLabels: {}
 
+nodeSelector: {}
+
+affinity: {}
+
+tolerations: []
+
 # legacyGroupVersion: "ipam.legacy.com/v1alpha1"
 legacyGroupVersion: ""
 annotationPrefix: "ipam.adevinta.com"


### PR DESCRIPTION
This PR updates the Helm chart to allow configuration of nodeSelector, affinity, and tolerations in the deployment manifest. No default values are set; the configuration is optional and customizable.