### PR TITLE
fix: multiarch build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager cmd/ingress-allowlisting-controller/main.go
+RUN CGO_ENABLED=0 go build -a -o manager cmd/ingress-allowlisting-controller/main.go
 
 FROM ubuntu as ca-certificates
 


### PR DESCRIPTION
# Changes
- Removed `GO111MODULE` as it's ignored from Go 1.21+.
- Removed `GOOS` and `GOARCH` to make multiarch build works.