### PR TITLE
feat: support full JSONPath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/moby/spdystream v0.4.0 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/ohler55/ojg v1.27.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/vladimirvivien/gexe v0.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/ohler55/ojg v1.27.0 h1:1JzdkMpDc/X9bzRaN1+8AFLnrSiFy96yDSaeACCGD5U=
+github.com/ohler55/ojg v1.27.0/go.mod h1:/Y5dGWkekv9ocnUixuETqiL58f+5pAsUfg5P8e7Pa2o=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -154,7 +154,14 @@ func processCSV(reader io.Reader, processing ipamv1alpha1.Processing) ([]string,
 func processYAMLFormat(reader io.Reader, processing ipamv1alpha1.Processing) ([]string, error) {
 	// If JSONPath is specified, use it to extract data
 	if processing.JSONPath != "" {
-		parser, err := jp.ParseString(strings.Trim(processing.JSONPath, "{}"))
+		jsonPath := processing.JSONPath
+		// Normalize path, remove outer brackets
+		if strings.HasPrefix(jsonPath, "{") && strings.HasSuffix(jsonPath, "}") {
+			jsonPath = strings.TrimPrefix(jsonPath, "{")
+			jsonPath = strings.TrimSuffix(jsonPath, "}")
+		}
+
+		parser, err := jp.ParseString(jsonPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse jsonpath: %w", err)
 		}

--- a/pkg/controllers/cidrs_controller_test.go
+++ b/pkg/controllers/cidrs_controller_test.go
@@ -634,7 +634,7 @@ func TestCIDRsReconcileFromAWSRules(t *testing.T) {
 			Location: ipamv1alpha1.CIDRsLocation{
 				URI: "https://ip-ranges.amazonaws.com/ip-ranges.json",
 				Processing: ipamv1alpha1.Processing{
-					JSONPath: "{.prefixes[?(@.service == 'EC2')].ip_prefix}",
+					JSONPath: "{.prefixes[?(@.service == 'EC2' && (@.region == 'eu-central-1' || @.region == 'GLOBAL'))].ip_prefix}",
 				},
 			},
 		}},


### PR DESCRIPTION
Support more complex `JSONPath` within `?(...)`
* `&&`/`||` logical operators
* `==` / `!=` comparators
* `(...)` nested brackets with nested logic

example:
```
JSONPath: "{.prefixes[?(@.service == 'EC2' && (@.region == 'eu-central-1' || @.region == 'GLOBAL'))].ip_prefix}",
```