### PR TITLE
feat: parameterize Virtual Pod Autoscaler

### DIFF
--- a/helm-chart/ingress-allowlisting-controller/Chart.yaml
+++ b/helm-chart/ingress-allowlisting-controller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for managing Ingress Controller Allowlisting in namespaces
 name: ingress-allowlisting-controller
-version: 0.1.3
+version: 0.1.4

--- a/helm-chart/ingress-allowlisting-controller/templates/vpa.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/vpa.yaml
@@ -9,14 +9,11 @@ spec:
     kind: Deployment
     name: {{ .Release.Name }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: {{ .Values.vpa.updateMode }}
   resourcePolicy:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
-      minAllowed:
-        cpu: 100m
-        memory: 128M
-      maxAllowed:
-        memory: "1Gi"
-        cpu: "1"
+    {{- with .Values.vpa.containerPolicy }}
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{ end }}

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -11,6 +11,16 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+vpa:
+  updateMode: "InPlaceOrRecreate"
+  containerPolicy:
+    maxAllowed:
+      cpu: "1"
+      memory: "1Gi"
+    minAllowed:
+      cpu: 100m
+      memory: 128M
+
 gateway:
   enabled: false
 

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -12,7 +12,7 @@ resources:
     memory: 128Mi
 
 vpa:
-  updateMode: "InPlaceOrRecreate"
+  updateMode: "Recreate"
   containerPolicy:
     maxAllowed:
       cpu: "1"


### PR DESCRIPTION
* In huge environment hardcoded defaults for VPA
      are not enough for a proper functioning.

* `Auto` mode is [deprecated](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#updateMode-Auto)
      currently it's an alias for `Recreate`
      making it configurable too (so can be changed to`InPlaceOrRecreate`)