### PR TITLE
feat() HTTPRoute AllowListing Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,93 @@ spec:
     uri: https://api.github.com/repos/my-org/my-repo/contents/path/to/cidrs/file.json
 ```
 
+## Security considerations
+
+### Gateway vs HTTPRoute allowlisting - do not mix
+
+The Gateway controller creates an `AuthorizationPolicy` with `action: ALLOW` targeting the Gateway directly - this is **L4-level** protection (IP-only, no hostname matching).
+
+The HTTPRoute controller creates `AuthorizationPolicy` resources with `action: ALLOW` targeting the same Gateway but scoped per-hostname - this is **L7-level** protection.
+
+**Istio evaluates multiple ALLOW policies with OR logic.** A request is allowed if it matches ANY ALLOW policy targeting that resource. This means:
+
+```
+Request from 5.5.5.5 → app.example.com
+
+Gateway AP:  ALLOW from [10.0.0.0/8]               → ✗ no match
+HTTPRoute AP: ALLOW from [5.5.5.5/32] host app.example.com → ✓ match → ALLOWED
+```
+
+The HTTPRoute AP bypasses the Gateway AP entirely. **Do not use both `allowlist-group` on a Gateway and on its HTTPRoutes simultaneously.** Pick one level:
+
+- Use **Gateway-level** when you want a single uniform allowlist for all traffic through the gateway, regardless of hostname.
+- Use **HTTPRoute-level** when you need per-route control with different CIDRs per service.
+
+---
+
+### Protecting a cross-namespace Gateway with a DENY policy
+
+When using HTTPRoute-level allowlisting on a cross-namespace gateway, each HTTPRoute produces an ALLOW policy scoped to its hostnames. However, any hostname not covered by an ALLOW policy defaults to Istio's implicit deny - **unless another policy creates a gap**.
+
+To explicitly lock down which hostnames are permitted to reach the gateway at all, add a DENY policy that blocks anything not matching your expected hostname patterns:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: protect-gateway-hostnames
+  namespace: infra
+spec:
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        notHosts:
+        - '*.public.ns-staging00.example.com'
+        - '*.public.ns-staging01.example.com'
+        - '*.public.ns-staging02.example.com'
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-gateway
+```
+
+DENY rules take precedence over all ALLOW rules in Istio - this ensures that even if an ALLOW policy is misconfigured or overly broad, traffic to unexpected hostnames is blocked at the gateway level.
+
+---
+
+### Restricting which namespaces can attach to a cross-namespace Gateway
+
+A cross-namespace Gateway accepting routes from arbitrary namespaces is a lateral movement risk - any team that can create an HTTPRoute can attach to your gateway. Restrict attachment using the Gateway's `allowedRoutes` listener configuration:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-namespace-gateway
+  namespace: infra
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            cross-gateway-access: "true"
+```
+
+Only namespaces with the label `cross-gateway-access: "true"` can attach HTTPRoutes to this gateway. All other HTTPRoutes are rejected by the Gateway controller (`Accepted=False`) and no traffic flows for them - regardless of any `AuthorizationPolicy` that may exist.
+
+Combine all three layers for defence in depth:
+
+1. **Namespace label selector** on the Gateway listener - controls who can attach
+2. **HTTPRoute-level ALLOW policies** via this controller - controls which IPs can reach each service
+3. **Gateway-level DENY policy** on unexpected hostnames - prevents gaps from misconfigured or missing ALLOW policies
+
 ## Metrics
 The operator exposes a single metric `namespace_ingress_IpAllowlistingGroup_missing` that, when operated appropiately, it offer several information:
 

--- a/README.md
+++ b/README.md
@@ -556,6 +556,30 @@ Combine all three layers for defence in depth:
 2. **HTTPRoute-level ALLOW policies** via this controller - controls which IPs can reach each service
 3. **Gateway-level DENY policy** on unexpected hostnames - prevents gaps from misconfigured or missing ALLOW policies
 
+### AWS: preserving client IP for IP-based filtering
+
+`AuthorizationPolicy` rules match on `remoteIpBlocks` — this requires the **original client IP** to reach the Istio proxy. On AWS, load balancers terminate connections and replace the source IP with the LB's own address unless explicitly configured to propagate it.
+
+Without this configuration, all requests appear to come from the load balancer's IP and no allowlist rule will match correctly — effectively making the allowlist useless.
+
+**Solution: Proxy Protocol**
+
+Use Proxy Protocol to propagate the client IP through the AWS NLB to the Istio gateway:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gateway
+  annotations:
+    # Tell AWS LB to send Proxy Protocol v2 headers
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+    # Tell Istio's Envoy proxy to expect and parse Proxy Protocol
+    proxy.istio.io/config: '{"gatewayTopology": {"proxyProtocol": {}}}'
+```
+
+Both annotations are required — the first enables Proxy Protocol on the AWS side, the second tells Envoy to parse the protocol header and extract the real client IP for use in `remoteIpBlocks` matching.
+
 ## Metrics
 The operator exposes a single metric `namespace_ingress_IpAllowlistingGroup_missing` that, when operated appropiately, it offer several information:
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,20 @@ The content of the annotations can be a comma-separated list:
 
 The controller can also watch `HTTPRoute` resources and create an `AuthorizationPolicy` targeting the associated Istio Gateway.
 
-Enable the feature with the `--httproute-support-enabled` flag.
+Enable the feature via Helm:
+```yaml
+httproute:
+  enabled: true
+```
+
+Or directly with the flag: `--httproute-support-enabled`.
 
 Required annotations:
 - `ipam.adevinta.com/allowlist-group` and/or `ipam.adevinta.com/cluster-allowlist-group` — same as for Ingress
-- `ipam.adevinta.com/gateway` — name of the Istio Gateway to target
 
-**Simple case** — `AuthorizationPolicy` is created in the same namespace as the `HTTPRoute`:
+The gateway name, gateway namespace, and target namespace for the `AuthorizationPolicy` are all derived automatically from `spec.parentRefs` — no extra annotations needed.
+
+**Same-namespace case** — parentRef has no `namespace`, so the `AuthorizationPolicy` is created in the same namespace as the `HTTPRoute`:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -78,44 +85,45 @@ metadata:
   namespace: my-app
   annotations:
     ipam.adevinta.com/cluster-allowlist-group: office-ips
-    ipam.adevinta.com/gateway: my-gateway
 spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
   hostnames:
-    - app.example.com
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
+  - app.example.com
 ```
 
-The controller generates the following `AuthorizationPolicy` in `my-app`:
+The controller generates in `my-app`:
 
 ```yaml
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: my-route
+  name: my-route          # httproute name
   namespace: my-app
+  ownerReferences:        # automatically garbage-collected when the HTTPRoute is deleted
+  - kind: HTTPRoute
+    name: my-route
 spec:
   action: ALLOW
   rules:
   - from:
     - source:
         remoteIpBlocks:
-          - 10.0.0.0/8
-          - 192.168.0.0/16
+        - 10.0.0.0/8
+        - 192.168.0.0/16
     to:
     - operation:
         hosts:
-          - app.example.com
+        - app.example.com
   targetRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: my-gateway
 ```
 
-**Sophisticated case** — `AuthorizationPolicy` is created in a different namespace (e.g. where the Gateway lives) using the optional `ipam.adevinta.com/namespace` annotation:
+**Cross-namespace case** — parentRef has a `namespace` that differs from the HTTPRoute namespace. The `AuthorizationPolicy` is created in the gateway namespace:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -125,14 +133,143 @@ metadata:
   namespace: my-app
   annotations:
     ipam.adevinta.com/cluster-allowlist-group: office-ips
-    ipam.adevinta.com/gateway: my-gateway
-    ipam.adevinta.com/namespace: gateway-namespace
 spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-gateway
+    namespace: infra          # different from HTTPRoute namespace
   hostnames:
-    - app.example.com
+  - app.example.com
 ```
 
-The controller generates the same `AuthorizationPolicy` structure but in `gateway-namespace` instead of `my-app`.
+The controller generates in `infra`:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: my-app-my-route   # <httproute-namespace>-<httproute-name>
+  namespace: infra
+  # no ownerReference — cross-namespace owner references are not supported by Kubernetes
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+    to:
+    - operation:
+        hosts:
+        - app.example.com
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-gateway
+```
+
+> **Note:** Cross-namespace `AuthorizationPolicy` resources are not garbage-collected automatically when the `HTTPRoute` is deleted, because Kubernetes does not support cross-namespace owner references. They must be cleaned up manually.
+
+**Multiple gateways** — an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway. The first gets no index suffix; subsequent ones get `-1`, `-2`, etc.:
+
+```yaml
+spec:
+  parentRefs:
+  - name: internal-gateway           # → AuthorizationPolicy: my-route (or my-app-my-route)
+  - name: external-gateway           # → AuthorizationPolicy: my-route-1 (or my-app-my-route-1)
+```
+
+**Performance tuning** — if you have thousands of HTTPRoutes in a cluster, you can restrict the informer cache to only the ones opted into allowlisting using a label selector:
+
+```yaml
+httproute:
+  enabled: true
+  labelSelector: "ipam.adevinta.com/allowlisting=enabled"
+```
+
+Or via flag: `--httproute-label-selector=ipam.adevinta.com/allowlisting=enabled`.
+
+This filters at the API server level, reducing both memory usage and reconcile load.
+
+**Merge mode** — for staging environments where the same application is deployed across multiple namespaces (e.g. `ns-staging00`, `ns-staging01`, ...) and all point to a shared cross-namespace gateway, you can set `ipam.adevinta.com/merge` to a shared policy name to produce a single `AuthorizationPolicy` that covers all of them.
+
+The annotation value is both the **merge key** (which routes belong together) and the **name of the generated `AuthorizationPolicy`**. HTTPRoute names can be anything — typically they are hostname-based — and do not need to match.
+
+```yaml
+# In namespace ns-staging00:
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: chaos-monkey.public.ns-staging00.example.com
+  namespace: ns-staging00
+  annotations:
+    ipam.adevinta.com/allowlist-group: allowlist
+    ipam.adevinta.com/merge: chaos-monkey   # merge key = AP name
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-public
+    namespace: ns-infra
+  hostnames:
+  - chaos-monkey.public.ns-staging00.example.com
+---
+# In namespace ns-staging01:
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: chaos-monkey.public.ns-staging01.example.com
+  namespace: ns-staging01
+  annotations:
+    ipam.adevinta.com/allowlist-group: allowlist
+    ipam.adevinta.com/merge: chaos-monkey   # same merge key → same AP
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-public
+    namespace: ns-infra
+  hostnames:
+  - chaos-monkey.public.ns-staging01.example.com
+```
+
+The controller generates a **single** `AuthorizationPolicy` in `ns-infra`:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: chaos-monkey      # = the merge key (first gateway, no suffix; second would be chaos-monkey-1)
+  namespace: ns-infra
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 1.2.3.4/32       # union of all sibling CIDRs
+        - 5.6.7.8/32
+    to:
+    - operation:
+        hosts:
+        - chaos-monkey.public.ns-staging00.example.com
+        - chaos-monkey.public.ns-staging01.example.com
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-public
+```
+
+Merge rules:
+- All HTTPRoutes with the **same annotation value** and the **same target gateway** are merged together, regardless of their `metadata.name`.
+- CIDRs and hostnames are deduplicated across all siblings.
+- Reconciling any one sibling rebuilds the full merged policy.
+
+> **Security warning:** Merge mode is **not recommended for production** environments. Any namespace in the cluster that sets the same merge key and points to the same gateway will be pulled into the same `AuthorizationPolicy`. This means a team controlling a different namespace could add their application's hostnames and CIDRs to your policy, potentially opening access to their service through your allowlist — or having their service inadvertently protected by your rules.
+>
+> Merge mode is designed for **staging environments** where multiple namespace-isolated instances of the same application exist under the same team's control and share a single gateway.
 
 ### Example NetworkPolicy Resource
 Below are examples of NetworkPolicy resources with different `policyTypes` (Ingress or Egress).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,55 @@ The content of the annotations can be a comma-separated list:
 
 `MyCidrsObject,MyCidrsObject2,MyCidrsObject3`
 
+### Example Gateway Resource
+
+The controller can watch `Gateway` resources and create an `AuthorizationPolicy` in the same namespace targeting the gateway itself.
+
+Enable the feature via Helm:
+```yaml
+gateway:
+  enabled: true
+```
+
+Or directly with the flag: `--gateway-support-enabled`.
+
+Required annotations:
+- `ipam.adevinta.com/allowlist-group` and/or `ipam.adevinta.com/cluster-allowlist-group` - same as for Ingress
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gateway
+  namespace: my-app
+  annotations:
+    ipam.adevinta.com/cluster-allowlist-group: office-ips
+```
+
+The controller generates in `my-app`:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: my-gateway      # same as the Gateway name
+  namespace: my-app
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+```
+
+The `AuthorizationPolicy` is created in the same namespace as the `Gateway` and uses `targetRef` (singular) pointing directly at the gateway - no cross-namespace support, no hostnames, no merge mode. The AP is owned by the `Gateway` resource and garbage-collected automatically when the `Gateway` is deleted.
+
 ### Example HTTPRoute Resource
 
 The controller can also watch `HTTPRoute` resources and create an `AuthorizationPolicy` targeting the associated Istio Gateway.
@@ -71,11 +120,11 @@ httproute:
 Or directly with the flag: `--httproute-support-enabled`.
 
 Required annotations:
-- `ipam.adevinta.com/allowlist-group` and/or `ipam.adevinta.com/cluster-allowlist-group` — same as for Ingress
+- `ipam.adevinta.com/allowlist-group` and/or `ipam.adevinta.com/cluster-allowlist-group` - same as for Ingress
 
-The gateway name, gateway namespace, and target namespace for the `AuthorizationPolicy` are all derived automatically from `spec.parentRefs` — no extra annotations needed.
+The gateway name, gateway namespace, and target namespace for the `AuthorizationPolicy` are all derived automatically from `spec.parentRefs` - no extra annotations needed.
 
-**Same-namespace case** — parentRef has no `namespace`, so the `AuthorizationPolicy` is created in the same namespace as the `HTTPRoute`:
+**Same-namespace case** - parentRef has no `namespace`, so the `AuthorizationPolicy` is created in the same namespace as the `HTTPRoute`:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -123,7 +172,7 @@ spec:
     name: my-gateway
 ```
 
-**Cross-namespace case** — parentRef has a `namespace` that differs from the HTTPRoute namespace. The `AuthorizationPolicy` is created in the gateway namespace:
+**Cross-namespace case** - parentRef has a `namespace` that differs from the HTTPRoute namespace. The `AuthorizationPolicy` is created in the gateway namespace:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -151,7 +200,7 @@ kind: AuthorizationPolicy
 metadata:
   name: my-app-my-route   # <httproute-namespace>-<httproute-name>
   namespace: infra
-  # no ownerReference — cross-namespace owner references are not supported by Kubernetes
+  # no ownerReference - cross-namespace owner references are not supported by Kubernetes
 spec:
   action: ALLOW
   rules:
@@ -170,7 +219,7 @@ spec:
     name: cross-namespace-gateway
 ```
 
-> **Note:** Cross-namespace `AuthorizationPolicy` resources are not garbage-collected automatically when the `HTTPRoute` is deleted. Kubernetes does not support cross-namespace owner references, so the controller cannot set one — the API server would silently strip it anyway. This means stale APs can accumulate when routes are deleted, have their `parentRefs` changed, or switch between normal and merge mode.
+> **Note:** Cross-namespace `AuthorizationPolicy` resources are not garbage-collected automatically when the `HTTPRoute` is deleted. Kubernetes does not support cross-namespace owner references, so the controller cannot set one - the API server would silently strip it anyway. This means stale APs can accumulate when routes are deleted, have their `parentRefs` changed, or switch between normal and merge mode.
 >
 > **Automatic cleanup on restart:** every time the controller starts, it runs a one-time sweep over all `AuthorizationPolicy` resources it owns (identified by the `app.kubernetes.io/managed-by=ingress-allowlisting-controller` label). Any AP whose owner `HTTPRoute` no longer exists, or that the current route configuration would no longer produce, is deleted. Restarting the controller is therefore sufficient to clean up any accumulated orphans.
 >
@@ -181,7 +230,7 @@ spec:
 > kubectl rollout restart deployment/ingress-allowlisting-controller -n <namespace>
 > ```
 
-**Multiple gateways** — an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway. The first gets no index suffix; subsequent ones get `-1`, `-2`, etc.:
+**Multiple gateways** - an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway. The first gets no index suffix; subsequent ones get `-1`, `-2`, etc.:
 
 ```yaml
 spec:
@@ -190,7 +239,7 @@ spec:
   - name: external-gateway           # → AuthorizationPolicy: my-route-1 (or my-app-my-route-1)
 ```
 
-**Performance tuning** — if you have thousands of HTTPRoutes in a cluster, you can restrict the informer cache to only the ones opted into allowlisting using a label selector:
+**Performance tuning** - if you have thousands of HTTPRoutes in a cluster, you can restrict the informer cache to only the ones opted into allowlisting using a label selector:
 
 ```yaml
 httproute:
@@ -202,9 +251,9 @@ Or via flag: `--httproute-label-selector=ipam.adevinta.com/allowlisting=enabled`
 
 This filters at the API server level, reducing both memory usage and reconcile load.
 
-**Merge mode** — for staging environments where the same application is deployed across multiple namespaces (e.g. `ns-staging00`, `ns-staging01`, ...) and all point to a shared cross-namespace gateway, you can set `ipam.adevinta.com/merge` to a shared policy name to produce a single `AuthorizationPolicy` that covers all of them.
+**Merge mode** - for staging environments where the same application is deployed across multiple namespaces (e.g. `ns-staging00`, `ns-staging01`, ...) and all point to a shared cross-namespace gateway, you can set `ipam.adevinta.com/merge` to a shared policy name to produce a single `AuthorizationPolicy` that covers all of them.
 
-The annotation value is both the **merge key** (which routes belong together) and the **name of the generated `AuthorizationPolicy`**. HTTPRoute names can be anything — typically they are hostname-based — and do not need to match.
+The annotation value is both the **merge key** (which routes belong together) and the **name of the generated `AuthorizationPolicy`**. HTTPRoute names can be anything - typically they are hostname-based - and do not need to match.
 
 ```yaml
 # In namespace ns-staging00:
@@ -276,7 +325,7 @@ Merge rules:
 - CIDRs and hostnames are deduplicated across all siblings.
 - Reconciling any one sibling rebuilds the full merged policy.
 
-> **Security warning:** Merge mode is **not recommended for production** environments. Any namespace in the cluster that sets the same merge key and points to the same gateway will be pulled into the same `AuthorizationPolicy`. This means a team controlling a different namespace could add their application's hostnames and CIDRs to your policy, potentially opening access to their service through your allowlist — or having their service inadvertently protected by your rules.
+> **Security warning:** Merge mode is **not recommended for production** environments. Any namespace in the cluster that sets the same merge key and points to the same gateway will be pulled into the same `AuthorizationPolicy`. This means a team controlling a different namespace could add their application's hostnames and CIDRs to your policy, potentially opening access to their service through your allowlist - or having their service inadvertently protected by your rules.
 >
 > Merge mode is designed for **staging environments** where multiple namespace-isolated instances of the same application exist under the same team's control and share a single gateway.
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ The controller generates in `my-app`:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: my-route          # httproute name
+  name: my-gateway-my-route     # {gateway.Name}-{httproute.Name}
   namespace: my-app
-  ownerReferences:        # automatically garbage-collected when the HTTPRoute is deleted
+  ownerReferences:               # automatically garbage-collected when the HTTPRoute is deleted
   - kind: HTTPRoute
     name: my-route
 spec:
@@ -198,7 +198,7 @@ The controller generates in `infra`:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: my-app-my-route   # <httproute-namespace>-<httproute-name>
+  name: cross-namespace-gateway-my-app-my-route   # {gateway.Name}-{httproute.Namespace}-{httproute.Name}
   namespace: infra
   # no ownerReference - cross-namespace owner references are not supported by Kubernetes
 spec:
@@ -230,14 +230,16 @@ spec:
 > kubectl rollout restart deployment/ingress-allowlisting-controller -n <namespace>
 > ```
 
-**Multiple gateways** - an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway. The first gets no index suffix; subsequent ones get `-1`, `-2`, etc.:
+**Multiple gateways** - an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway, each prefixed with the gateway name:
 
 ```yaml
 spec:
   parentRefs:
-  - name: internal-gateway           # → AuthorizationPolicy: <httproute-namespace>-<httproute-name>
-  - name: external-gateway           # → AuthorizationPolicy: <httproute-namespace>-<httproute-name>-1
+  - name: internal-gateway           # → AuthorizationPolicy: internal-gateway-{httproute.Name}
+  - name: external-gateway           # → AuthorizationPolicy: external-gateway-{httproute.Name}
 ```
+
+Cross-namespace refs follow the same prefix convention: `{gateway.Name}-{httproute.Namespace}-{httproute.Name}`.
 
 **Performance tuning** - if you have thousands of HTTPRoutes in a cluster, you can restrict the informer cache to only the ones opted into allowlisting using a label selector:
 
@@ -293,13 +295,14 @@ spec:
   - chaos-monkey.public.ns-staging01.example.com
 ```
 
-The controller generates a **single** `AuthorizationPolicy` in `ns-infra`:
+The controller generates a **single** `AuthorizationPolicy` in `ns-infra`. Routes with the **same CIDR set** are compacted into one `rule`; routes with **different CIDR sets** each get their own `rule` — this preserves the security boundary (a CIDR allowed for one hostname cannot implicitly reach another):
 
 ```yaml
+# Example A: both routes share the same CIDR set (e.g. same allowlist object)
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: chaos-monkey      # = the merge key (first gateway, no suffix; second would be chaos-monkey-1)
+  name: chaos-monkey      # = the merge key
   namespace: ns-infra
 spec:
   action: ALLOW
@@ -307,12 +310,43 @@ spec:
   - from:
     - source:
         remoteIpBlocks:
-        - 1.2.3.4/32       # union of all sibling CIDRs
-        - 5.6.7.8/32
+        - 1.2.3.4/32       # shared CIDRs → one rule
     to:
     - operation:
         hosts:
         - chaos-monkey.public.ns-staging00.example.com
+    - operation:
+        hosts:
+        - chaos-monkey.public.ns-staging01.example.com
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-public
+---
+# Example B: each route has a different CIDR set → one rule per CIDR set
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: chaos-monkey
+  namespace: ns-infra
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 1.2.3.4/32       # only ns-staging00's CIDRs
+    to:
+    - operation:
+        hosts:
+        - chaos-monkey.public.ns-staging00.example.com
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 5.6.7.8/32       # only ns-staging01's CIDRs
+    to:
+    - operation:
+        hosts:
         - chaos-monkey.public.ns-staging01.example.com
   targetRefs:
   - group: gateway.networking.k8s.io
@@ -322,8 +356,38 @@ spec:
 
 Merge rules:
 - All HTTPRoutes with the **same annotation value** and the **same target gateway** are merged together, regardless of their `metadata.name`.
-- CIDRs and hostnames are deduplicated across all siblings.
+- Routes with the **same sorted CIDR set** share one `from` block (compacted for readability). Routes with different CIDR sets each get their own `rule` — security isolation is preserved.
+- Within a CIDR group, routes with the **same hostname set** share one `to` block, with all their paths collected together.
 - Reconciling any one sibling rebuilds the full merged policy.
+
+**Granularity** - by default the controller creates one `AuthorizationPolicy` per HTTPRoute rule (one per path set). Use the `ipam.adevinta.com/granularity` annotation to change this behaviour:
+
+| Value | AP count | AP name | `to` block |
+|---|---|---|---|
+| absent / `rule` | one per rule | `{gw}-{route}-{path}` | hosts + path from that rule |
+| `host` | one per route | `{gw}-{route}` | hosts only, no path restriction |
+
+```yaml
+# granularity=rule (default): separate AP per path
+metadata:
+  annotations:
+    ipam.adevinta.com/granularity: rule   # or omit entirely
+spec:
+  rules:
+  - matches:
+    - path:
+        value: /api      # → AP named {gw}-{route}-api
+  - matches:
+    - path:
+        value: /health   # → AP named {gw}-{route}-health
+---
+# granularity=host: one AP for the whole route, no path restriction
+metadata:
+  annotations:
+    ipam.adevinta.com/granularity: host
+```
+
+`granularity` also applies inside **merge mode**: when a sibling has `granularity=host`, its rule contributes to the merged AP without any path restriction; when it has `granularity=rule` (default), each rule's paths are included.
 
 > **Security warning:** Merge mode is **not recommended for production** environments. Any namespace in the cluster that sets the same merge key and points to the same gateway will be pulled into the same `AuthorizationPolicy`. This means a team controlling a different namespace could add their application's hostnames and CIDRs to your policy, potentially opening access to their service through your allowlist - or having their service inadvertently protected by your rules.
 >

--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ spec:
 ```yaml
 spec:
   parentRefs:
-  - name: internal-gateway           # → AuthorizationPolicy: my-route (or my-app-my-route)
-  - name: external-gateway           # → AuthorizationPolicy: my-route-1 (or my-app-my-route-1)
+  - name: internal-gateway           # → AuthorizationPolicy: <httproute-namespace>-<httproute-name>
+  - name: external-gateway           # → AuthorizationPolicy: <httproute-namespace>-<httproute-name>-1
 ```
 
 **Performance tuning** - if you have thousands of HTTPRoutes in a cluster, you can restrict the informer cache to only the ones opted into allowlisting using a label selector:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,16 @@ spec:
     name: cross-namespace-gateway
 ```
 
-> **Note:** Cross-namespace `AuthorizationPolicy` resources are not garbage-collected automatically when the `HTTPRoute` is deleted, because Kubernetes does not support cross-namespace owner references. They must be cleaned up manually.
+> **Note:** Cross-namespace `AuthorizationPolicy` resources are not garbage-collected automatically when the `HTTPRoute` is deleted. Kubernetes does not support cross-namespace owner references, so the controller cannot set one — the API server would silently strip it anyway. This means stale APs can accumulate when routes are deleted, have their `parentRefs` changed, or switch between normal and merge mode.
+>
+> **Automatic cleanup on restart:** every time the controller starts, it runs a one-time sweep over all `AuthorizationPolicy` resources it owns (identified by the `app.kubernetes.io/managed-by=ingress-allowlisting-controller` label). Any AP whose owner `HTTPRoute` no longer exists, or that the current route configuration would no longer produce, is deleted. Restarting the controller is therefore sufficient to clean up any accumulated orphans.
+>
+> **Hard reset:** to remove all APs managed by this controller and let it rebuild from scratch:
+> ```bash
+> kubectl delete authorizationpolicies -A -l app.kubernetes.io/managed-by=ingress-allowlisting-controller
+> # then restart the controller
+> kubectl rollout restart deployment/ingress-allowlisting-controller -n <namespace>
+> ```
 
 **Multiple gateways** — an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway. The first gets no index suffix; subsequent ones get `-1`, `-2`, etc.:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,82 @@ The content of the annotations can be a comma-separated list:
 
 `MyCidrsObject,MyCidrsObject2,MyCidrsObject3`
 
+### Example HTTPRoute Resource
+
+The controller can also watch `HTTPRoute` resources and create an `AuthorizationPolicy` targeting the associated Istio Gateway.
+
+Enable the feature with the `--httproute-support-enabled` flag.
+
+Required annotations:
+- `ipam.adevinta.com/allowlist-group` and/or `ipam.adevinta.com/cluster-allowlist-group` — same as for Ingress
+- `ipam.adevinta.com/gateway` — name of the Istio Gateway to target
+
+**Simple case** — `AuthorizationPolicy` is created in the same namespace as the `HTTPRoute`:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-route
+  namespace: my-app
+  annotations:
+    ipam.adevinta.com/cluster-allowlist-group: office-ips
+    ipam.adevinta.com/gateway: my-gateway
+spec:
+  hostnames:
+    - app.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+```
+
+The controller generates the following `AuthorizationPolicy` in `my-app`:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: my-route
+  namespace: my-app
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        remoteIpBlocks:
+          - 10.0.0.0/8
+          - 192.168.0.0/16
+    to:
+    - operation:
+        hosts:
+          - app.example.com
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+```
+
+**Sophisticated case** — `AuthorizationPolicy` is created in a different namespace (e.g. where the Gateway lives) using the optional `ipam.adevinta.com/namespace` annotation:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-route
+  namespace: my-app
+  annotations:
+    ipam.adevinta.com/cluster-allowlist-group: office-ips
+    ipam.adevinta.com/gateway: my-gateway
+    ipam.adevinta.com/namespace: gateway-namespace
+spec:
+  hostnames:
+    - app.example.com
+```
+
+The controller generates the same `AuthorizationPolicy` structure but in `gateway-namespace` instead of `my-app`.
+
 ### Example NetworkPolicy Resource
 Below are examples of NetworkPolicy resources with different `policyTypes` (Ingress or Egress).
 

--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,184 @@
+# Ingress Allowlisting Controller — Deep Dive
+
+## Architecture: Reconcilers vs Writers
+
+The controller has two conceptually different types of components:
+
+### Reconcilers (source-driven)
+Watch a Kubernetes object that **already exists** and inject CIDRs into it.
+The object is owned by someone else — the reconciler only mutates part of its spec.
+
+| Reconciler | Watches | Mutates | Target |
+|---|---|---|---|
+| `IngressReconciler` | `networking.k8s.io/v1 Ingress` | `nginx.ingress.kubernetes.io/whitelist-source-range` annotation | Nginx / cloud LB controllers |
+| `NetworkPolicyReconciler` | `networking.k8s.io/v1 NetworkPolicy` | `spec.ingress[].from[].ipBlock` | Any CNI enforcing standard NetworkPolicy |
+
+### Writers (creator-driven, Gateway API)
+Resolve a Gateway API object chain (`HTTPRoute → Gateway → GatewayClass → controllerName`) and **create a new enforcement object** specific to the ingress controller in use.
+Writers are registered in a registry keyed by `GatewayClass.spec.controllerName`.
+
+| Writer | Interface | Creates | Target Controller |
+|---|---|---|---|
+| `IstioL4Writer` | `L4PolicyWriter` | `security.istio.io/v1 AuthorizationPolicy` (TargetRef → Gateway) | Istio |
+| `IstioL7Writer` | `L7PolicyWriter` + `MergeableL7PolicyWriter` | `security.istio.io/v1 AuthorizationPolicy` (TargetRef → Gateway, per HTTPRoute) | Istio |
+
+### Resolution chain for writers
+
+```
+HTTPRoute
+  └─ spec.parentRefs[].name/namespace
+       └─ Gateway
+            └─ spec.gatewayClassName
+                 └─ GatewayClass
+                      └─ spec.controllerName  ──► L4WriterRegistry / L7WriterRegistry
+                                                        └─ Writer.Apply(...)
+                                                             └─ creates enforcement object
+```
+
+### Why interfaces?
+
+Writers are registered by controller name. Adding support for a new ingress controller (e.g. Envoy Gateway, Traefik) requires only:
+1. Implement `L4PolicyWriter` or `L7PolicyWriter`
+2. Add `RequiredPermissions()` so the RBAC preflight check covers it automatically
+3. Register in `controllers.go` — nothing else changes
+
+The reconciler (`HTTPRouteAllowlistingReconciler`, `GatewayAllowlistingReconciler`) is completely agnostic to the underlying enforcement technology.
+
+---
+
+## Controller Support Matrix
+
+### Gateway API — L4 (Gateway level)
+
+| Controller | `GatewayClass.controllerName` | Creates | Granularity | Implemented |
+|---|---|---|---|---|
+| Istio | `istio.io/gateway-controller` | `AuthorizationPolicy` (TargetRef → Gateway) | Gateway | ✅ |
+| Envoy Gateway | `gateway.envoyproxy.io/gatewayclass-controller` | `SecurityPolicy` (TargetRef → Gateway) | Gateway | 🔲 TODO |
+| Traefik | `traefik.io/gateway-controller` | — (no L4 Gateway-level policy) | — | 🔲 TODO |
+| Cilium | `io.cilium/gateway-controller` | — (pod-selector based, not Gateway API aware) | — | ➖ N/A |
+
+### Gateway API — L7 (HTTPRoute level)
+
+| Controller | `GatewayClass.controllerName` | Creates | Granularity | Merge support | Path support | Implemented |
+|---|---|---|---|---|---|---|
+| Istio | `istio.io/gateway-controller` | `AuthorizationPolicy` (TargetRef → Gateway, per route) | HTTPRoute + host + path | ✅ (`MergeableL7PolicyWriter`) | ✅ (`granularity` annotation) | ✅ |
+| Traefik | `traefik.io/gateway-controller` | `Middleware` (IPAllowList) | HTTPRoute | ➖ not supported | ➖ not applicable | 🔲 TODO |
+| Envoy Gateway | `gateway.envoyproxy.io/gatewayclass-controller` | `SecurityPolicy` (TargetRef → HTTPRoute) | HTTPRoute + host + path | 🔲 TODO | 🔲 TODO | 🔲 TODO |
+
+### Legacy / Non-Gateway API
+
+| Reconciler | Watches | Enforced by | L4/L7 | Granularity | Notes |
+|---|---|---|---|---|---|
+| `IngressReconciler` | `networking.k8s.io/v1 Ingress` | Nginx, cloud LBs | L7 | Ingress object | Patches annotation in place |
+| `NetworkPolicyReconciler` | `networking.k8s.io/v1 NetworkPolicy` | Any standard-compliant CNI | L3/L4 | Pod selector | See CNI support below |
+
+### CNI support via `networking.k8s.io/v1 NetworkPolicy`
+
+The `NetworkPolicyReconciler` writes standard `NetworkPolicy` objects with `ipBlock` rules.
+Any CNI that enforces the standard spec picks them up automatically:
+
+| CNI | Enforces `networking.k8s.io/v1 NetworkPolicy` | Notes |
+|---|---|---|
+| AWS VPC CNI | ✅ | Native, no extra config |
+| Calico | ✅ | Also has own `crd.projectcalico.org` CRDs with richer expression language |
+| Antrea | ✅ | Also has own `ClusterNetworkPolicy` with priority/tier system |
+| Cilium | ✅ (deprecated) | Prefers `CiliumNetworkPolicy`; standard spec supported but being phased out |
+| kube-router | ✅ | Standard spec only, no custom CRDs |
+| Flannel | ❌ | No network policy enforcement — objects are created but silently ignored |
+
+---
+
+## Pod-Oriented vs Gateway-Oriented
+
+A key architectural distinction:
+
+```
+Gateway API writers    → target Gateway/HTTPRoute objects (Istio, Traefik, Envoy Gateway)
+                         enforcement object knows about the Gateway topology
+
+Pod-oriented writers   → target pods via label selectors (Cilium CNP, Calico NP, Antrea NP)
+                         enforcement object has no concept of Gateway or HTTPRoute
+                         workload labels flow down: Deployment → ReplicaSet → Pod
+```
+
+Pod-oriented controllers are architecturally equivalent to the existing `NetworkPolicyReconciler` — a separate reconciler watching a pre-existing object, not a writer plugged into the Gateway API registry. If Cilium-native (`CiliumNetworkPolicy`) or Calico-native support is needed in the future, it should follow the same pattern as `NetworkPolicyReconciler`, not the writer interface.
+
+---
+
+## AuthorizationPolicy Naming
+
+### Convention
+
+All AP names follow a deterministic pattern derived from the objects involved. The gateway name is always the prefix — this prevents collisions when multiple gateways share the same namespace.
+
+| Scenario | Pattern | Example |
+|---|---|---|
+| Same-namespace, no paths | `{gw}-{route}` | `my-gateway-my-route` |
+| Same-namespace, single path | `{gw}-{route}-{pathSafe(path)}` | `my-gateway-my-route-api` |
+| Same-namespace, multiple paths | `{gw}-{route}-{pathSafe(paths[0])}-{fnv32hex}` | `my-gateway-my-route-api-3d2a1f8c` |
+| Cross-namespace, no paths | `{gw}-{routeNS}-{route}` | `my-gateway-app-ns-my-route` |
+| Cross-namespace, single path | `{gw}-{routeNS}-{route}-{pathSafe(path)}` | `my-gateway-app-ns-my-route-api` |
+| Cross-namespace, multiple paths | `{gw}-{routeNS}-{route}-{pathSafe(paths[0])}-{fnv32hex}` | `my-gateway-app-ns-my-route-api-3d2a1f8c` |
+| Merge mode | `{mergeKey}` | `chaos-monkey` |
+
+### `pathSafe` encoding
+
+`pathSafe` converts a URL path to a valid Kubernetes name segment:
+
+1. Escape `-` → `--` (so the separator `-` is never ambiguous)
+2. Trim leading and trailing `/`
+3. Replace remaining `/` with `-`
+
+Examples:
+
+| Path | `pathSafe` result |
+|---|---|
+| `/api` | `api` |
+| `/admin/users` | `admin-users` |
+| `/admin-users` | `admin--users` |
+| `/` | `""` → caller uses sentinel `-root` → final name ends `--root` |
+
+The double-dash prefix produced by `/` (`--root`) is unreachable by any real path, since `pathSafe` escapes all literal `-` first.
+
+### Multi-path collision protection
+
+When a rule has a single path the suffix is the plain readable `pathSafe` result. When a rule has **multiple paths** a hash is appended:
+
+```
+suffix = pathSafe(sorted_paths[0]) + "-" + hex8(fnv32a(sorted_paths))
+```
+
+- `sorted_paths[0]` gives a human-readable hint — operators can identify the rule at a glance
+- The FNV-32a hash covers the **full sorted set**, so two rules sharing the same first path but differing elsewhere get different names
+- Sorting makes the name order-independent — reordering matches in an HTTPRoute rule does not rename the AP
+- FNV-32a output is hex digits only (`[0-9a-f]`) — always a valid Kubernetes name segment
+
+Collision table:
+
+| Input | Suffix | Notes |
+|---|---|---|
+| `["/api"]` | `api` | single path, readable, no hash |
+| `["/api", "/health"]` | `api-3d2a1f8c` | multi-path, first + hash |
+| `["/api", "/admin"]` | `api-7b2e41f0` | same first path, different hash |
+| `["/api-v2"]` | `api--v2` | single path, dash escaped — never clashes with above |
+
+A same-namespace gateway named `my-gw` with route `r` would produce:
+```
+gw-r-api            ← single path /api
+gw-r-api-3d2a1f8c   ← paths [/api, /health]
+gw-r-api-7b2e41f0   ← paths [/api, /admin]
+gw-r-api--v2        ← single path /api-v2 (dash escaped)
+```
+
+None of these can ever collide.
+
+---
+
+## TODO
+
+| Priority | Item | Notes |
+|---|---|---|
+| 🟡 Medium | Envoy Gateway `SecurityPolicy` writer (L4 + L7) | Closest Istio equivalent; `targetRef` model is nearly identical |
+| 🟡 Medium | Traefik `Middleware` writer | IP allowlisting via `IPAllowList`; path filtering handled by HTTPRoute routing itself — no extra path restriction in the Middleware needed |
+| 🟠 Low | Cilium-native `CiliumNetworkPolicy` reconciler | Pod-selector based; separate reconciler pattern, not a writer |
+| 🟠 Low | Calico-native `NetworkPolicy` reconciler | Expression language differs from standard K8s; separate reconciler pattern |

--- a/README2.md
+++ b/README2.md
@@ -114,60 +114,38 @@ All AP names follow a deterministic pattern derived from the objects involved. T
 | Scenario | Pattern | Example |
 |---|---|---|
 | Same-namespace, no paths | `{gw}-{route}` | `my-gateway-my-route` |
-| Same-namespace, single path | `{gw}-{route}-{pathSafe(path)}` | `my-gateway-my-route-api` |
-| Same-namespace, multiple paths | `{gw}-{route}-{pathSafe(paths[0])}-{fnv32hex}` | `my-gateway-my-route-api-3d2a1f8c` |
+| Same-namespace, with paths | `{gw}-{route}-{fnv32hex}` | `my-gateway-my-route-3d2a1f8c` |
 | Cross-namespace, no paths | `{gw}-{routeNS}-{route}` | `my-gateway-app-ns-my-route` |
-| Cross-namespace, single path | `{gw}-{routeNS}-{route}-{pathSafe(path)}` | `my-gateway-app-ns-my-route-api` |
-| Cross-namespace, multiple paths | `{gw}-{routeNS}-{route}-{pathSafe(paths[0])}-{fnv32hex}` | `my-gateway-app-ns-my-route-api-3d2a1f8c` |
+| Cross-namespace, with paths | `{gw}-{routeNS}-{route}-{fnv32hex}` | `my-gateway-app-ns-my-route-3d2a1f8c` |
 | Merge mode | `{mergeKey}` | `chaos-monkey` |
 
-### `pathSafe` encoding
+### Path-based collision protection
 
-`pathSafe` converts a URL path to a valid Kubernetes name segment:
-
-1. Escape `-` → `--` (so the separator `-` is never ambiguous)
-2. Trim leading and trailing `/`
-3. Replace remaining `/` with `-`
-
-Examples:
-
-| Path | `pathSafe` result |
-|---|---|
-| `/api` | `api` |
-| `/admin/users` | `admin-users` |
-| `/admin-users` | `admin--users` |
-| `/` | `""` → caller uses sentinel `-root` → final name ends `--root` |
-
-The double-dash prefix produced by `/` (`--root`) is unreachable by any real path, since `pathSafe` escapes all literal `-` first.
-
-### Multi-path collision protection
-
-When a rule has a single path the suffix is the plain readable `pathSafe` result. When a rule has **multiple paths** a hash is appended:
+When a rule has paths, a FNV-32a hash of the **full sorted path set** is appended:
 
 ```
-suffix = pathSafe(sorted_paths[0]) + "-" + hex8(fnv32a(sorted_paths))
+suffix = hex8(fnv32a(sorted_paths))
 ```
 
-- `sorted_paths[0]` gives a human-readable hint — operators can identify the rule at a glance
-- The FNV-32a hash covers the **full sorted set**, so two rules sharing the same first path but differing elsewhere get different names
 - Sorting makes the name order-independent — reordering matches in an HTTPRoute rule does not rename the AP
+- The hash covers the full set, so two rules with different paths always get different names
 - FNV-32a output is hex digits only (`[0-9a-f]`) — always a valid Kubernetes name segment
+- The human-readable part comes from the HTTPRoute name itself, not the path
 
 Collision table:
 
 | Input | Suffix | Notes |
 |---|---|---|
-| `["/api"]` | `api` | single path, readable, no hash |
-| `["/api", "/health"]` | `api-3d2a1f8c` | multi-path, first + hash |
-| `["/api", "/admin"]` | `api-7b2e41f0` | same first path, different hash |
-| `["/api-v2"]` | `api--v2` | single path, dash escaped — never clashes with above |
+| `["/api"]` | `3d2a1f8c` | single path, hash only |
+| `["/api", "/health"]` | `5f1a9c2e` | multi-path, hash of full set |
+| `["/api", "/admin"]` | `7b2e41f0` | different set, different hash |
+| `["/api/*"]` | `8e4d3b1a` | glob path, same format |
 
 A same-namespace gateway named `my-gw` with route `r` would produce:
 ```
-gw-r-api            ← single path /api
-gw-r-api-3d2a1f8c   ← paths [/api, /health]
-gw-r-api-7b2e41f0   ← paths [/api, /admin]
-gw-r-api--v2        ← single path /api-v2 (dash escaped)
+gw-r                ← no paths (granularity=host)
+gw-r-3d2a1f8c       ← paths [/api, /api/*]
+gw-r-5f1a9c2e       ← paths [/admin, /admin/*]
 ```
 
 None of these can ever collide.

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -43,6 +43,7 @@ func main() {
 	var enableLeaderElection bool
 	var gatewaySupportEnabled bool
 	var networkPolicySupportEnabled bool
+	var httpRouteSupportEnabled bool
 	var as string
 	var annotationPrefix string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -51,6 +52,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&gatewaySupportEnabled, "gateway-support-enabled", false, "Enable gateway support for the controller")
 	flag.BoolVar(&networkPolicySupportEnabled, "networkpolicy-support-enabled", false, "Enable networkpolicy support for the controller")
+	flag.BoolVar(&httpRouteSupportEnabled, "httproute-support-enabled", false, "Enable HTTPRoute support for the controller")
 	flag.StringVar(&legacyGroupVersion, "legacy-group-version", "", "Enables coexistence of two CRDS with different groups for CIDR objects.")
 	flag.StringVar(&as, "as", "", "The user to impersonate to run this controller")
 	flag.StringVar(&annotationPrefix, "annotation-prefix", "ipam.adevinta.com", "Enables coexistence of two CRDS with different groups for CIDR objects.")
@@ -81,7 +83,7 @@ func main() {
 		setupLog.Fatal(err, "unable to start manager")
 	}
 
-	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, legacyGroupVersion, "", annotationPrefix); err != nil {
+	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix); err != nil {
 		setupLog.Fatal(err, "unable to setup controllers")
 	}
 

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -21,10 +21,15 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers"
@@ -44,6 +49,7 @@ func main() {
 	var gatewaySupportEnabled bool
 	var networkPolicySupportEnabled bool
 	var httpRouteSupportEnabled bool
+	var httpRouteLabelSelector string
 	var as string
 	var annotationPrefix string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -53,6 +59,7 @@ func main() {
 	flag.BoolVar(&gatewaySupportEnabled, "gateway-support-enabled", false, "Enable gateway support for the controller")
 	flag.BoolVar(&networkPolicySupportEnabled, "networkpolicy-support-enabled", false, "Enable networkpolicy support for the controller")
 	flag.BoolVar(&httpRouteSupportEnabled, "httproute-support-enabled", false, "Enable HTTPRoute support for the controller")
+	flag.StringVar(&httpRouteLabelSelector, "httproute-label-selector", "", "Label selector to filter HTTPRoutes watched by the controller (e.g. 'app.kubernetes.io/managed-by=my-team'). Restricts the informer cache at the API server level.")
 	flag.StringVar(&legacyGroupVersion, "legacy-group-version", "", "Enables coexistence of two CRDS with different groups for CIDR objects.")
 	flag.StringVar(&as, "as", "", "The user to impersonate to run this controller")
 	flag.StringVar(&annotationPrefix, "annotation-prefix", "ipam.adevinta.com", "Enables coexistence of two CRDS with different groups for CIDR objects.")
@@ -70,7 +77,7 @@ func main() {
 		restConfig.Impersonate.UserName = as
 	}
 
-	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -78,7 +85,20 @@ func main() {
 		WebhookServer:    webhook.NewServer(webhook.Options{Port: 9443}),
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "c72663fe.github.com/adevinta/ingress-allowlisting-controller",
-	})
+	}
+	if httpRouteSupportEnabled && httpRouteLabelSelector != "" {
+		selector, err := labels.Parse(httpRouteLabelSelector)
+		if err != nil {
+			setupLog.Fatal(err, "invalid --httproute-label-selector")
+		}
+		mgrOptions.Cache = cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&gatewayApiv1.HTTPRoute{}: {Label: selector},
+			},
+		}
+		setupLog.Infof("HTTPRoute informer cache restricted to label selector: %s", httpRouteLabelSelector)
+	}
+	mgr, err := ctrl.NewManager(restConfig, mgrOptions)
 	if err != nil {
 		setupLog.Fatal(err, "unable to start manager")
 	}

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,12 +29,17 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -77,6 +84,10 @@ func main() {
 		restConfig.Impersonate.UserName = as
 	}
 
+	// nil client is fine here — writers are only used to call RequiredPermissions(), not for K8s ops.
+	l4Writers, l7Writers := controllers.BuildWriterRegistries(nil, "preflight", annotationPrefix)
+	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, l4Writers, l7Writers)
+
 	mgrOptions := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -111,5 +122,79 @@ func main() {
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Fatal(err, "problem running manager")
+	}
+}
+
+func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {
+	cs := kubernetes.NewForConfigOrDie(restConfig)
+
+	var perms []writers.Permission
+
+	// Always required — CIDRs and secret/configmap sources used by all controllers.
+	perms = append(perms,
+		writers.Permission{Group: "ipam.adevinta.com", Resource: "cidrs", Verb: "get"},
+		writers.Permission{Group: "ipam.adevinta.com", Resource: "clustercidrs", Verb: "get"},
+		writers.Permission{Group: "", Resource: "secrets", Verb: "get"},
+		writers.Permission{Group: "", Resource: "configmaps", Verb: "get"},
+	)
+
+	if gatewayEnabled {
+		perms = append(perms,
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gateways", Verb: "get"},
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses", Verb: "get"},
+		)
+		for _, w := range l4Writers {
+			if pp, ok := w.(writers.PermissionProvider); ok {
+				perms = append(perms, pp.RequiredPermissions()...)
+			}
+		}
+	}
+
+	if httpRouteEnabled {
+		perms = append(perms,
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "httproutes", Verb: "get"},
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gateways", Verb: "get"},
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses", Verb: "get"},
+		)
+		for _, w := range l7Writers {
+			if pp, ok := w.(writers.PermissionProvider); ok {
+				perms = append(perms, pp.RequiredPermissions()...)
+			}
+		}
+	}
+
+	if networkPolicyEnabled {
+		perms = append(perms,
+			writers.Permission{Group: "networking.k8s.io", Resource: "networkpolicies", Verb: "get"},
+			writers.Permission{Group: "networking.k8s.io", Resource: "networkpolicies", Verb: "update"},
+		)
+	}
+
+	// Deduplicate before checking.
+	seen := map[writers.Permission]struct{}{}
+	for _, p := range perms {
+		if _, already := seen[p]; already {
+			continue
+		}
+		seen[p] = struct{}{}
+
+		sar := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Verb:     p.Verb,
+					Group:    p.Group,
+					Resource: p.Resource,
+				},
+			},
+		}
+		result, err := cs.AuthorizationV1().SelfSubjectAccessReviews().Create(
+			context.Background(), sar, metav1.CreateOptions{},
+		)
+		if err != nil {
+			setupLog.Fatal(fmt.Errorf("RBAC preflight: cannot check %s %s/%s: %w", p.Verb, p.Group, p.Resource, err), "preflight failed")
+		}
+		if !result.Status.Allowed {
+			setupLog.Fatal(fmt.Errorf("missing permission: cannot %s %s/%s — fix ClusterRole and redeploy", p.Verb, p.Group, p.Resource), "RBAC preflight failed")
+		}
 	}
 }

--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -40,6 +40,12 @@ spec:
 {{- if .Values.networkpolicy.enabled }}
         - "--networkpolicy-support-enabled"
 {{- end }}
+{{- if .Values.httproute.enabled }}
+        - "--httproute-support-enabled"
+{{- with .Values.httproute.labelSelector }}
+        - "--httproute-label-selector={{ . }}"
+{{- end }}
+{{- end }}
 {{ with .Values.legacyGroupVersion }}
         - "--legacy-group-version={{ . }}"
 {{- end }}

--- a/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
@@ -35,7 +35,7 @@ rules:
   verbs: ["get", "watch", "list"]
 {{- if .Values.gateway.enabled }}
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["gateways"]
+  resources: ["gateways", "gatewayclasses"]
   verbs: ["list","get", "watch"]
 - apiGroups: ["security.istio.io"]
   resources: ["authorizationpolicies"]
@@ -43,7 +43,7 @@ rules:
 {{- end }}
 {{- if .Values.httproute.enabled }}
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["httproutes"]
+  resources: ["httproutes", "gateways", "gatewayclasses"]
   verbs: ["list","get", "watch"]
 - apiGroups: ["security.istio.io"]
   resources: ["authorizationpolicies"]

--- a/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
@@ -41,6 +41,14 @@ rules:
   resources: ["authorizationpolicies"]
   verbs: ["list", "get", "watch", "create", "update", "delete", "patch"]
 {{- end }}
+{{- if .Values.httproute.enabled }}
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes"]
+  verbs: ["list","get", "watch"]
+- apiGroups: ["security.istio.io"]
+  resources: ["authorizationpolicies"]
+  verbs: ["list", "get", "watch", "create", "update", "delete", "patch"]
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -24,6 +24,10 @@ vpa:
 gateway:
   enabled: false
 
+httproute:
+  enabled: false
+  labelSelector: ""
+
 networkpolicy:
   enabled: false
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -7,9 +7,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -26,6 +28,19 @@ type setupError struct {
 
 func (e *setupError) Log(logger logr.Logger) {
 	logger.Error(e, "unable to create controller", "controller", "Ingress")
+}
+
+// BuildWriterRegistries constructs the L4 and L7 writer registries based on which controllers
+// are enabled. Called from main.go before the manager starts so permissions can be checked.
+func BuildWriterRegistries(c client.Client, managedBy, annotationPrefix string) (writers.L4WriterRegistry, writers.L7WriterRegistry) {
+	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: c}
+	l4 := writers.L4WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL4Writer(c),
+	}
+	l7 := writers.L7WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL7Writer(c, managedBy, cidrResolver),
+	}
+	return l4, l7
 }
 
 func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string) error {
@@ -72,12 +87,26 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 		}
 	}
 
+	managedBy := "ingress-allowlisting-controller"
+	if namePrefix != "" {
+		managedBy = namePrefix + "-ingress-allowlisting-controller"
+	}
+
+	l4Writers := writers.L4WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL4Writer(mgr.GetClient()),
+	}
+	l7Writers := writers.L7WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL7Writer(mgr.GetClient(), managedBy, cidrResolver),
+		//		writers.TraefikControllerName: writers.NewTraefikL7Writer(mgr.GetClient(), managedBy, cidrResolver),
+	}
+
 	if gatewaySupportEnabled {
 		gatewayReconciler := GatewayAllowlistingReconciler{
 			Client:             mgr.GetClient(),
 			Scheme:             mgr.GetScheme(),
 			LegacyGroupVersion: legacyGroupVersion,
 			CidrResolver:       cidrResolver,
+			L4Writers:          l4Writers,
 		}
 		if err := gatewayReconciler.SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "Gateway"}
@@ -101,6 +130,7 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 			Scheme:             mgr.GetScheme(),
 			LegacyGroupVersion: legacyGroupVersion,
 			CidrResolver:       cidrResolver,
+			L7Writers:          l7Writers,
 		}
 		if err := httpRouteReconciler.SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "HTTPRoute"}
@@ -151,6 +181,9 @@ func Scheme(legacyGroupVersion string) (*runtime.Scheme, error) {
 	if err := istiosecurityv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
+	//	if err := writers.AddTraefikToScheme(scheme); err != nil {
+	//		return nil, err
+	//	}
 
 	if legacyGroupVersion != "" {
 		var err error

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -28,7 +28,7 @@ func (e *setupError) Log(logger logr.Logger) {
 	logger.Error(e, "unable to create controller", "controller", "Ingress")
 }
 
-func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string) error {
+func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string) error {
 	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: mgr.GetClient()}
 
 	if err := (&IngressReconciler{
@@ -92,6 +92,18 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 		}
 		if err := networkPolicyReconciler.SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "Gateway"}
+		}
+	}
+
+	if httpRouteSupportEnabled {
+		httpRouteReconciler := HTTPRouteAllowlistingReconciler{
+			Client:             mgr.GetClient(),
+			Scheme:             mgr.GetScheme(),
+			LegacyGroupVersion: legacyGroupVersion,
+			CidrResolver:       cidrResolver,
+		}
+		if err := httpRouteReconciler.SetupWithManager(mgr, namePrefix); err != nil {
+			return &setupError{error: err, controllerType: "HTTPRoute"}
 		}
 	}
 

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -352,6 +352,10 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "group-name", Namespace: currentNamespaceName},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
 	}
+	gwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "istio"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: "istio.io/gateway-controller"},
+	}
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test",
@@ -360,8 +364,9 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 				"ipam.example.com/allowlist-group": "group-name",
 			},
 		},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gwClass, gateway).Build()
 
 	k8sCache := &testCache{Client: k8sClient, scheme: extendedScheme}
 
@@ -442,6 +447,10 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "group-name"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
 	}
+	gwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "istio"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: "istio.io/gateway-controller"},
+	}
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test",
@@ -450,8 +459,9 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 				"ipam.example.com/cluster-allowlist-group": "group-name",
 			},
 		},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gwClass, gateway).Build()
 
 	k8sCache := &testCache{Client: k8sClient, scheme: extendedScheme}
 

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -241,7 +241,7 @@ func TestCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, "", t.Name(), "ipam.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.example.com"))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -313,7 +313,7 @@ func TestClusterCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, "", t.Name(), "legacy.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "legacy.example.com"))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -382,7 +382,7 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com"))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -472,7 +472,7 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com"))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))

--- a/pkg/controllers/gateway_controller.go
+++ b/pkg/controllers/gateway_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -12,14 +11,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	istioApiSecurityV1 "istio.io/api/security/v1"
-	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
 
@@ -29,10 +27,12 @@ type GatewayAllowlistingReconciler struct {
 	LegacyGroupVersion string
 	Prefix             string
 	CidrResolver       resolvers.CidrResolver
+	L4Writers          writers.L4WriterRegistry
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
 
 func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -41,7 +41,7 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 	if err := r.Get(ctx, req.NamespacedName, &gateway); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Infof("Gateway %s being reconciled. Creating/updating allowlist...", gateway.GetName())
+	log.Infof("Gateway %s being reconciled. Creating/updating writers...", gateway.GetName())
 	var allowedIps []string
 	var err error
 	allowedIps, err = r.CidrResolver.GetCidrsFromObject(ctx, &gateway)
@@ -52,39 +52,26 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	generatedAuthorizationPolicy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gateway.Name,
-			Namespace: gateway.Namespace,
-		},
+	// Resolve GatewayClass to find which writer to use
+	gwClass := &gatewayApiv1.GatewayClass{}
+	if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, err
+		}
+		log.Infof("GatewayClass %s not found, skipping gateway %s", gateway.Spec.GatewayClassName, gateway.Name)
+		return ctrl.Result{}, nil
 	}
 
-	_, err = ctrl.CreateOrUpdate(ctx, r.Client, generatedAuthorizationPolicy, func() error {
-		generatedAuthorizationPolicy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW, // ALLOW is the default action; somehow, the action field is empty when examining the resource after creation
-			Rules: []*istioApiSecurityV1.Rule{
-				{
-					From: []*istioApiSecurityV1.Rule_From{
-						{
-							Source: &istioApiSecurityV1.Source{
-								RemoteIpBlocks: allowedIps,
-							},
-						},
-					},
-				},
-			},
-			TargetRef: &istioApiTypeV1beta1.PolicyTargetReference{
-				Name:  gateway.Name,
-				Kind:  "Gateway",
-				Group: "gateway.networking.k8s.io",
-			},
-		}
-		return nil
-	})
-	if err != nil {
+	writer, ok := r.L4Writers[string(gwClass.Spec.ControllerName)]
+	if !ok {
+		log.Infof("no L4 writer registered for controller %s, skipping gateway %s", gwClass.Spec.ControllerName, gateway.Name)
+		return ctrl.Result{}, nil
+	}
+
+	if err := writer.Apply(ctx, r.Scheme, &gateway, allowedIps); err != nil {
 		return ctrl.Result{}, err
 	}
-	log.Infof("AuthorizationPolicy %s created/updated for gateway %s", generatedAuthorizationPolicy.Name, gateway.GetName())
+	log.Infof("AuthorizationPolicy created/updated for gateway %s", gateway.GetName())
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controllers/gateway_controller.go
+++ b/pkg/controllers/gateway_controller.go
@@ -42,23 +42,20 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log.Infof("Gateway %s being reconciled. Creating/updating writers...", gateway.GetName())
-	var allowedIps []string
-	var err error
-	allowedIps, err = r.CidrResolver.GetCidrsFromObject(ctx, &gateway)
-	if err == r.CidrResolver.AnnotationNotFoundError() {
-		return ctrl.Result{}, nil
-	}
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 
-	// Resolve GatewayClass to find which writer to use
+	// Resolve GatewayClass and writer first — needed for both apply and delete paths.
 	gwClass := &gatewayApiv1.GatewayClass{}
 	if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
-		log.Infof("GatewayClass %s not found, skipping gateway %s", gateway.Spec.GatewayClassName, gateway.Name)
+		// GatewayClass was deleted — attempt cleanup with all registered writers to avoid orphaned APs.
+		for _, w := range r.L4Writers {
+			if err := w.Delete(ctx, &gateway); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		log.Infof("GatewayClass %s not found, cleaned up gateway %s", gateway.Spec.GatewayClassName, gateway.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -66,6 +63,20 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 	if !ok {
 		log.Infof("no L4 writer registered for controller %s, skipping gateway %s", gwClass.Spec.ControllerName, gateway.Name)
 		return ctrl.Result{}, nil
+	}
+
+	var allowedIps []string
+	var err error
+	allowedIps, err = r.CidrResolver.GetCidrsFromObject(ctx, &gateway)
+	if err == r.CidrResolver.AnnotationNotFoundError() {
+		// Annotation removed — delete any previously created L4 AP.
+		if err := writer.Delete(ctx, &gateway); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if err := writer.Apply(ctx, r.Scheme, &gateway, allowedIps); err != nil {
@@ -90,7 +101,7 @@ func (r *GatewayAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nameP
 		build = build.Named(namePrefix + "-gateway")
 	}
 	if r.LegacyGroupVersion != "" {
-		build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newGatewaysFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
+		build = build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newGatewaysFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
 			Watches(&ipamv1alpha1_legacy.CIDRs{}, handler.EnqueueRequestsFromMapFunc(newGatewaysFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation())))
 	}
 	return build.Complete(r)
@@ -102,7 +113,7 @@ func newGatewaysFromCIDRFuncMap(c client.Client, annotation string) handler.MapF
 		options := client.ListOptions{
 			Namespace: cidr.GetNamespace(),
 		}
-		err := c.List(context.Background(), gateways, &options)
+		err := c.List(ctx, gateways, &options)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/pkg/controllers/gateway_controller_test.go
+++ b/pkg/controllers/gateway_controller_test.go
@@ -589,3 +589,71 @@ func TestClusterCidrToGatewayMapper(t *testing.T) {
 		assert.Len(t, requests, 0)
 	})
 }
+
+// TestGatewayAnnotationRemovalDeletesAP verifies end-to-end that removing the allowlist
+// annotation from a Gateway triggers deletion of its AuthorizationPolicy.
+func TestGatewayAnnotationRemovalDeletesAP(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	gwClass := newGatewayClass("istio")
+	gateway := &gatewayApiv1.Gateway{
+		ObjectMeta: v1.ObjectMeta{Namespace: "ns", Name: "my-gw", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, gwClass, gateway).Build()
+	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile — AP is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-gw", Namespace: "ns"}})
+	assert.NoError(t, err)
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	assert.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw", Namespace: "ns"}, ap))
+
+	// Remove the allowlist annotation.
+	gateway.Annotations = map[string]string{}
+	assert.NoError(t, k8sClient.Update(context.Background(), gateway))
+
+	// Second reconcile — AP must be deleted.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-gw", Namespace: "ns"}})
+	assert.NoError(t, err)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw", Namespace: "ns"}, ap)
+	assert.True(t, apierrors.IsNotFound(err), "AP must be deleted after gateway annotation is removed")
+}
+
+// TestReconcileGatewayClassDeletedCleansUpAP verifies that when a GatewayClass is deleted,
+// the gateway controller still cleans up the AuthorizationPolicy rather than leaving it orphaned.
+func TestReconcileGatewayClassDeletedCleansUpAP(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	gwClass := newGatewayClass("istio")
+	gateway := &gatewayApiv1.Gateway{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, gateway, gwClass).Build()
+	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile — AP is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	assert.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, ap))
+
+	// Delete the GatewayClass.
+	assert.NoError(t, k8sClient.Delete(context.Background(), gwClass))
+
+	// Second reconcile — AP must be cleaned up even though GatewayClass is gone.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, ap)
+	assert.True(t, apierrors.IsNotFound(err), "AP must be deleted when GatewayClass is removed")
+}

--- a/pkg/controllers/gateway_controller_test.go
+++ b/pkg/controllers/gateway_controller_test.go
@@ -10,6 +10,7 @@ import (
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -32,10 +33,23 @@ func init() {
 	}
 }
 
+// newGatewayClass creates an Istio GatewayClass with the given name.
+func newGatewayClass(name string) *gatewayApiv1.GatewayClass {
+	return &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: name},
+		Spec: gatewayApiv1.GatewayClassSpec{
+			ControllerName: gatewayApiv1.GatewayController(writers.IstioControllerName),
+		},
+	}
+}
+
 func newGatewayReconciler(t *testing.T, k8sClient client.Client, scheme *runtime.Scheme) *GatewayAllowlistingReconciler {
 	t.Helper()
 	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
-	return &GatewayAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme}
+	l4Writers := writers.L4WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL4Writer(k8sClient),
+	}
+	return &GatewayAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme, L4Writers: l4Writers}
 }
 
 // cases:
@@ -65,13 +79,15 @@ func TestReconcileGateway(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32", "8.8.8.8/32"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/cluster-allowlist-group": "globalnet",
 			"ipam.adevinta.com/allowlist-group":         "localnet,dnssource",
 		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, globalCidrs).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, globalCidrs, gwClass).Build()
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
@@ -123,12 +139,14 @@ func TestReconcileGatewayWithClusterCIDR(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "anotherglobalnet"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"15.13.12.0/24"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/cluster-allowlist-group": "globalnet,anotherglobalnet",
 		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, globalNet, anotherGlobalNet).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, globalNet, anotherGlobalNet, gwClass).Build()
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: v1.ObjectMeta{
@@ -179,6 +197,7 @@ func TestReconcileGatewayNoAnnotations(t *testing.T) {
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
+	// Note: no GatewayClass needed here because the reconciler returns early on AnnotationNotFoundError
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
@@ -197,10 +216,12 @@ func TestReconcileGatewayPartialNotFound(t *testing.T) {
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
 	}
 
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet,notexisting"}},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, gateway, gwClass).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
@@ -250,10 +271,12 @@ func TestReconcileGatewayWithInvalidCIDRIpsNoError(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32", "8.8.8.8/32"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet,dnssource"}},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, gwClass).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
@@ -300,10 +323,12 @@ func TestReconcileGatewayWithInvalidCIDRIpsNoError(t *testing.T) {
 
 func TestReconcileGatewayCIDRsNotFound(t *testing.T) {
 	t.Run("Namespace CIDR not found", func(t *testing.T) {
+		gwClass := newGatewayClass("istio")
 		gateway := &gatewayApiv1.Gateway{
 			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "notexisting,alsonotexisting"}},
+			Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway).Build()
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, gwClass).Build()
 		reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 		expectedPolicy := istiosecurityv1.AuthorizationPolicy{
 			ObjectMeta: v1.ObjectMeta{
@@ -362,10 +387,12 @@ func TestReconcileGatewayCIDRsNotFound(t *testing.T) {
 	})
 
 	t.Run("Cluster CIDR not found", func(t *testing.T) {
+		gwClass := newGatewayClass("istio")
 		gateway := &gatewayApiv1.Gateway{
 			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/cluster-allowlist-group": "notexisting,alsonotexisting"}},
+			Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway).Build()
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, gwClass).Build()
 		reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 		expectedPolicy := istiosecurityv1.AuthorizationPolicy{
 			ObjectMeta: v1.ObjectMeta{
@@ -444,10 +471,12 @@ func TestReconcileGatewayInvalidAnnotationFormat(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32", "8.8.8.8/32"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet, dnssource"}},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, gwClass).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -485,7 +485,17 @@ func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nam
 			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
 		Watches(
 			&gatewayApiv1.HTTPRoute{},
-			r.mergeSiblingEnqueuer())
+			r.mergeSiblingEnqueuer(),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc:  func(e event.CreateEvent) bool { return false },
+				DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldKey := e.ObjectOld.GetAnnotations()[r.mergeAnnotation()]
+					newKey := e.ObjectNew.GetAnnotations()[r.mergeAnnotation()]
+					return oldKey != newKey && oldKey != ""
+				},
+			}))
 	if namePrefix != "" {
 		build = build.Named(namePrefix + "-httproute")
 	}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -37,7 +36,6 @@ type HTTPRouteAllowlistingReconciler struct {
 	LegacyGroupVersion string
 	Prefix             string
 	CidrResolver       resolvers.CidrResolver
-	startupCleanupOnce sync.Once
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
@@ -128,6 +126,7 @@ func (r *HTTPRouteAllowlistingReconciler) applyLabels(policy *istiosecurityv1.Au
 
 func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.DefaultLogger.WithContext(ctx).WithField("httproute", req.NamespacedName)
+
 	httproute := gatewayApiv1.HTTPRoute{}
 	if err := r.Get(ctx, req.NamespacedName, &httproute); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -151,7 +150,6 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			}
 			i++
 		}
-		r.runStartupCleanup(ctx)
 		return ctrl.Result{}, nil
 	}
 
@@ -199,16 +197,26 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", pt.namespace, pt.name, httproute.GetName())
 	}
 
-	r.runStartupCleanup(ctx)
-
 	return ctrl.Result{}, nil
 }
 
-// runStartupCleanup runs once after the first reconcile completes. It lists all APs managed by this
-// controller, checks whether the owning HTTPRoute still exists and would still produce that AP,
-// and deletes any that are orphaned. This handles APs left behind by previous controller runs.
+// cleanupRunnable returns a manager.Runnable that waits for the cache to sync and then
+// runs orphan cleanup exactly once at startup, independent of the reconcile loop.
+func cleanupRunnable(mgr ctrl.Manager, r *HTTPRouteAllowlistingReconciler) manager.Runnable {
+	return manager.RunnableFunc(func(ctx context.Context) error {
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
+			return nil
+		}
+		r.runStartupCleanup(ctx)
+		return nil
+	})
+}
+
+// runStartupCleanup lists all APs managed by this controller, checks whether the owning
+// HTTPRoute still exists and would still produce that AP, and deletes any that are orphaned.
+// This handles APs left behind by previous controller runs.
 func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context) {
-	r.startupCleanupOnce.Do(func() {
+	{
 		log := log.DefaultLogger.WithContext(ctx)
 		log.Infof("Running post-startup orphan cleanup for managed AuthorizationPolicies")
 
@@ -304,7 +312,7 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 			}
 			log.Infof("Startup cleanup: deleted orphaned AuthorizationPolicy %s/%s (owner: %s/%s)", ap.Namespace, ap.Name, ownerNS, ownerName)
 		}
-	})
+	}
 }
 
 func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {
@@ -472,6 +480,10 @@ func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nam
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.ObjectNew) || hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.ObjectOld)
 		},
+	}
+
+	if err := mgr.Add(cleanupRunnable(mgr, r)); err != nil {
+		return err
 	}
 
 	build := ctrl.NewControllerManagedBy(mgr).

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -1,0 +1,176 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	log "github.com/adevinta/go-log-toolkit"
+	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+type HTTPRouteAllowlistingReconciler struct {
+	client.Client
+	Scheme             *runtime.Scheme
+	LegacyGroupVersion string
+	Prefix             string
+	CidrResolver       resolvers.CidrResolver
+}
+
+// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
+
+func (r *HTTPRouteAllowlistingReconciler) gatewayAnnotation() string {
+	return r.CidrResolver.AnnotationPrefix + "/gateway"
+}
+
+func (r *HTTPRouteAllowlistingReconciler) namespaceAnnotation() string {
+	return r.CidrResolver.AnnotationPrefix + "/namespace"
+}
+
+func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.DefaultLogger.WithContext(ctx).WithField("httproute", req.NamespacedName)
+	httproute := gatewayApiv1.HTTPRoute{}
+	if err := r.Get(ctx, req.NamespacedName, &httproute); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	log.Infof("HTTPRoute %s being reconciled. Creating/updating allowlist...", httproute.GetName())
+
+	allowedIps, err := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
+	if err == r.CidrResolver.AnnotationNotFoundError() {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	annotations := httproute.GetAnnotations()
+	gatewayName, ok := annotations[r.gatewayAnnotation()]
+	if !ok || gatewayName == "" {
+		log.Infof("HTTPRoute %s has no %s annotation, skipping", httproute.GetName(), r.gatewayAnnotation())
+		return ctrl.Result{}, nil
+	}
+
+	targetNamespace := httproute.Namespace
+	if ns, ok := annotations[r.namespaceAnnotation()]; ok && ns != "" {
+		targetNamespace = ns
+	}
+
+	var hostnames []string
+	for _, h := range httproute.Spec.Hostnames {
+		hostnames = append(hostnames, string(h))
+	}
+
+	policyName := httproute.Name
+	generatedAuthorizationPolicy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: targetNamespace,
+		},
+	}
+
+	rules := []*istioApiSecurityV1.Rule{
+		{
+			From: []*istioApiSecurityV1.Rule_From{
+				{
+					Source: &istioApiSecurityV1.Source{
+						RemoteIpBlocks: allowedIps,
+					},
+				},
+			},
+		},
+	}
+	if len(hostnames) > 0 {
+		rules[0].To = []*istioApiSecurityV1.Rule_To{
+			{
+				Operation: &istioApiSecurityV1.Operation{
+					Hosts: hostnames,
+				},
+			},
+		}
+	}
+
+	_, err = ctrl.CreateOrUpdate(ctx, r.Client, generatedAuthorizationPolicy, func() error {
+		generatedAuthorizationPolicy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules:  rules,
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{
+					Name:  gatewayName,
+					Kind:  "Gateway",
+					Group: "gateway.networking.k8s.io",
+				},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", targetNamespace, policyName, httproute.GetName())
+
+	return ctrl.Result{}, nil
+}
+
+func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
+	build := ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayApiv1.HTTPRoute{}).
+		Owns(&istiosecurityv1.AuthorizationPolicy{}).
+		Watches(
+			&ipamv1alpha1.CIDRs{},
+			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation()))).
+		Watches(
+			&ipamv1alpha1.ClusterCIDRs{},
+			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation())))
+	if namePrefix != "" {
+		build = build.Named(namePrefix + "-httproute")
+	}
+	if r.LegacyGroupVersion != "" {
+		build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
+			Watches(&ipamv1alpha1_legacy.CIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation())))
+	}
+	return build.Complete(r)
+}
+
+func newHTTPRoutesFromCIDRFuncMap(c client.Client, annotation string) handler.MapFunc {
+	return func(ctx context.Context, cidr client.Object) []reconcile.Request {
+		httproutes := &gatewayApiv1.HTTPRouteList{}
+		options := client.ListOptions{
+			Namespace: cidr.GetNamespace(),
+		}
+		err := c.List(context.Background(), httproutes, &options)
+		if err != nil {
+			return []reconcile.Request{}
+		}
+		var requests []reconcile.Request
+		for _, httproute := range httproutes.Items {
+			val, ok := httproute.Annotations[annotation]
+			if !ok {
+				continue
+			}
+			cidrsFound := map[string]struct{}{}
+			for _, cidrName := range strings.Split(val, ",") {
+				cidrsFound[strings.TrimSpace(cidrName)] = struct{}{}
+			}
+			if _, found := cidrsFound[cidr.GetName()]; found {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: httproute.Namespace, Name: httproute.Name}})
+			}
+		}
+		return requests
+	}
+}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -218,21 +218,29 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 			return
 		}
 
+		// Safety check: list all HTTPRoutes once upfront. If the list call fails or returns
+		// empty while we have managed APs, the API server or cache may be in a degraded state.
+		// Abort rather than risk deleting valid APs based on a dirty read.
+		allRoutes := &gatewayApiv1.HTTPRouteList{}
+		if err := r.List(ctx, allRoutes); err != nil {
+			log.Errorf("startup cleanup: failed to list HTTPRoutes, aborting to avoid dirty-read deletions: %v", err)
+			return
+		}
+		if len(allRoutes.Items) == 0 && len(existing.Items) > 0 {
+			log.Infof("startup cleanup: no HTTPRoutes found but managed APs exist — skipping to avoid dirty-read deletions")
+			return
+		}
+
 		for _, ap := range existing.Items {
 			ap := ap
 			ownerNS := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
 			ownerName := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"]
 
 			if ownerNS == "merged" {
-				// Merge-mode AP: orphaned if no HTTPRoute with merge=<ownerName> pointing to any gateway exists
-				routes := &gatewayApiv1.HTTPRouteList{}
-				if err := r.List(ctx, routes); err != nil {
-					log.Errorf("startup cleanup: failed to list HTTPRoutes: %v", err)
-					return
-				}
+				// Merge-mode AP: orphaned if no HTTPRoute with merge=<ownerName> exists anywhere
 				found := false
-				for i := range routes.Items {
-					if routes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
+				for i := range allRoutes.Items {
+					if allRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
 						found = true
 						break
 					}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -31,6 +31,7 @@ import (
 
 type HTTPRouteAllowlistingReconciler struct {
 	client.Client
+	APIReader          client.Reader // bypasses cache — used only by startup cleanup to confirm deletions
 	Scheme             *runtime.Scheme
 	LegacyGroupVersion string
 	Prefix             string
@@ -237,7 +238,8 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 			ownerName := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"]
 
 			if ownerNS == "merged" {
-				// Merge-mode AP: orphaned if no HTTPRoute with merge=<ownerName> exists anywhere
+				// Merge-mode AP: first check the cache (fast path); if not found there, confirm
+				// via direct API server read to rule out label-selector filtering.
 				found := false
 				for i := range allRoutes.Items {
 					if allRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
@@ -248,9 +250,24 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 				if found {
 					continue
 				}
+				// Cache returned nothing — confirm via API server before deleting
+				directRoutes := &gatewayApiv1.HTTPRouteList{}
+				if err := r.APIReader.List(ctx, directRoutes); err != nil {
+					log.Errorf("startup cleanup: API reader failed to list HTTPRoutes: %v", err)
+					return
+				}
+				for i := range directRoutes.Items {
+					if directRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
+						found = true
+						break
+					}
+				}
+				if found {
+					continue
+				}
 			} else {
-				// Normal AP: orphaned if owner HTTPRoute no longer exists, or has since switched to merge mode,
-				// or no longer produces an AP at this exact {namespace, name}.
+				// Normal AP: check cache first; if the route is absent from cache, confirm via
+				// direct API server read — it may simply be outside the label selector.
 				route := &gatewayApiv1.HTTPRoute{}
 				err := r.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, route)
 				if client.IgnoreNotFound(err) != nil {
@@ -258,12 +275,26 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 					return
 				}
 				if err == nil && route.Annotations[r.mergeAnnotation()] == "" {
-					// Route still exists and is not in merge mode — check it still produces this AP
+					// Route is in cache and not in merge mode — check it still produces this AP
 					if routeProducesPolicy(route, ap.Namespace, ap.Name) {
 						continue
 					}
 				}
-				// Falls through if: route not found, route switched to merge, or route no longer produces this AP
+				if err != nil {
+					// Not in cache — confirm via API server before deleting
+					directRoute := &gatewayApiv1.HTTPRoute{}
+					directErr := r.APIReader.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, directRoute)
+					if client.IgnoreNotFound(directErr) != nil {
+						log.Errorf("startup cleanup: API reader failed to get HTTPRoute %s/%s: %v", ownerNS, ownerName, directErr)
+						return
+					}
+					if directErr == nil {
+						// Route exists on API server but not in cache — outside label selector, keep AP
+						continue
+					}
+					// Confirmed 404 on API server — truly gone, fall through to delete
+				}
+				// Falls through if: confirmed gone, switched to merge, or no longer produces this AP
 			}
 
 			if err := r.Delete(ctx, ap); client.IgnoreNotFound(err) != nil {
@@ -397,6 +428,7 @@ func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {
 
 func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
 	r.Prefix = namePrefix
+	r.APIReader = mgr.GetAPIReader()
 	annotationPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object)

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -8,8 +8,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	istioApiSecurityV1 "istio.io/api/security/v1"
@@ -127,9 +130,26 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	return ctrl.Result{}, nil
 }
 
+func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {
+	a := obj.GetAnnotations()
+	_, hasLocal := a[annotationPrefix+"/allowlist-group"]
+	_, hasCluster := a[annotationPrefix+"/cluster-allowlist-group"]
+	return hasLocal || hasCluster
+}
+
 func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
+	annotationPredicate := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object) },
+		// Check both old and new: annotation removal must trigger reconcile to clean up the AuthorizationPolicy.
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.ObjectNew) || hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.ObjectOld)
+		},
+	}
+
 	build := ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayApiv1.HTTPRoute{}).
+		For(&gatewayApiv1.HTTPRoute{}, builder.WithPredicates(annotationPredicate)).
 		Owns(&istiosecurityv1.AuthorizationPolicy{}).
 		Watches(
 			&ipamv1alpha1.CIDRs{},

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,12 +40,50 @@ type HTTPRouteAllowlistingReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
 
-func (r *HTTPRouteAllowlistingReconciler) gatewayAnnotation() string {
-	return r.CidrResolver.AnnotationPrefix + "/gateway"
+// gatewayParentRefs returns all parentRefs that target a Gateway.
+func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
+	var refs []gatewayApiv1.ParentReference
+	for _, ref := range httproute.Spec.ParentRefs {
+		if ref.Kind != nil && *ref.Kind != "Gateway" {
+			continue
+		}
+		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
 }
 
-func (r *HTTPRouteAllowlistingReconciler) namespaceAnnotation() string {
-	return r.CidrResolver.AnnotationPrefix + "/namespace"
+func (r *HTTPRouteAllowlistingReconciler) mergeAnnotation() string {
+	return r.CidrResolver.AnnotationPrefix + "/merge"
+}
+
+func (r *HTTPRouteAllowlistingReconciler) managedByValue() string {
+	if r.Prefix != "" {
+		return r.Prefix + "-ingress-allowlisting-controller"
+	}
+	return "ingress-allowlisting-controller"
+}
+
+// invalidLabelValue matches characters not allowed in k8s label values: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
+var invalidLabelValue = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
+
+func labelSafe(s string) string {
+	v := invalidLabelValue.ReplaceAllString(s, "_")
+	if len(v) > 63 {
+		v = v[:63]
+	}
+	return v
+}
+
+func (r *HTTPRouteAllowlistingReconciler) applyLabels(policy *istiosecurityv1.AuthorizationPolicy, ownerNamespace, ownerName string) {
+	if policy.Labels == nil {
+		policy.Labels = map[string]string{}
+	}
+	policy.Labels["app.kubernetes.io/managed-by"] = r.managedByValue()
+	policy.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"] = labelSafe(ownerNamespace)
+	policy.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"] = labelSafe(ownerName)
 }
 
 func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -54,6 +94,26 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	}
 	log.Infof("HTTPRoute %s being reconciled. Creating/updating allowlist...", httproute.GetName())
 
+	parentRefs := gatewayParentRefs(&httproute)
+	if len(parentRefs) == 0 {
+		log.Infof("HTTPRoute %s has no Gateway parentRefs, skipping", httproute.GetName())
+		return ctrl.Result{}, nil
+	}
+
+	if mergeKey := httproute.Annotations[r.mergeAnnotation()]; mergeKey != "" {
+		i := 0
+		for _, ref := range parentRefs {
+			if ref.Namespace == nil || string(*ref.Namespace) == httproute.Namespace {
+				continue // merge only applies to cross-namespace refs
+			}
+			if err := r.reconcileMergedGateway(ctx, &httproute, ref, mergeKey, i); err != nil {
+				return ctrl.Result{}, err
+			}
+			i++
+		}
+		return ctrl.Result{}, nil
+	}
+
 	allowedIps, err := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
 	if err == r.CidrResolver.AnnotationNotFoundError() {
 		return ctrl.Result{}, nil
@@ -62,72 +122,164 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	annotations := httproute.GetAnnotations()
-	gatewayName, ok := annotations[r.gatewayAnnotation()]
-	if !ok || gatewayName == "" {
-		log.Infof("HTTPRoute %s has no %s annotation, skipping", httproute.GetName(), r.gatewayAnnotation())
-		return ctrl.Result{}, nil
-	}
-
-	targetNamespace := httproute.Namespace
-	if ns, ok := annotations[r.namespaceAnnotation()]; ok && ns != "" {
-		targetNamespace = ns
-	}
-
 	var hostnames []string
 	for _, h := range httproute.Spec.Hostnames {
 		hostnames = append(hostnames, string(h))
 	}
 
-	policyName := httproute.Name
-	generatedAuthorizationPolicy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      policyName,
-			Namespace: targetNamespace,
-		},
-	}
+	rules := buildAuthorizationRules(allowedIps, hostnames)
 
-	rules := []*istioApiSecurityV1.Rule{
-		{
-			From: []*istioApiSecurityV1.Rule_From{
-				{
-					Source: &istioApiSecurityV1.Source{
-						RemoteIpBlocks: allowedIps,
+	for i, ref := range parentRefs {
+		gatewayName := string(ref.Name)
+		targetNamespace := httproute.Namespace
+		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != httproute.Namespace
+
+		baseName := httproute.Name
+		if crossNamespace {
+			targetNamespace = string(*ref.Namespace)
+			baseName = httproute.Namespace + "-" + httproute.Name
+		}
+		policyName := baseName
+		if i > 0 {
+			policyName = fmt.Sprintf("%s-%d", baseName, i)
+		}
+
+		policy := &istiosecurityv1.AuthorizationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      policyName,
+				Namespace: targetNamespace,
+			},
+		}
+		_, err = ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
+			if !crossNamespace {
+				// Same-namespace: owner reference enables automatic GC when the HTTPRoute is deleted.
+				// Cross-namespace owner references are silently stripped by the API server; controller-runtime
+				// rejects them early, so we skip the call entirely.
+				if err := ctrl.SetControllerReference(&httproute, policy, r.Scheme); err != nil {
+					return err
+				}
+			}
+			r.applyLabels(policy, httproute.Namespace, httproute.Name)
+			policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+				Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+				Rules:  rules,
+				TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+					{
+						Name:  gatewayName,
+						Kind:  "Gateway",
+						Group: "gateway.networking.k8s.io",
 					},
 				},
-			},
-		},
+			}
+			return nil
+		})
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", targetNamespace, policyName, httproute.GetName())
 	}
-	if len(hostnames) > 0 {
-		rules[0].To = []*istioApiSecurityV1.Rule_To{
-			{
-				Operation: &istioApiSecurityV1.Operation{
-					Hosts: hostnames,
-				},
-			},
+
+	return ctrl.Result{}, nil
+}
+
+func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {
+	log := log.DefaultLogger.WithContext(ctx)
+	gatewayName := string(ref.Name)
+	gatewayNamespace := string(*ref.Namespace)
+
+	allRoutes := &gatewayApiv1.HTTPRouteList{}
+	if err := r.List(ctx, allRoutes); err != nil {
+		return err
+	}
+
+	seenIPs := map[string]struct{}{}
+	seenHosts := map[string]struct{}{}
+	var mergedIPs, mergedHosts []string
+
+	for i := range allRoutes.Items {
+		sibling := &allRoutes.Items[i]
+		if sibling.Annotations[r.mergeAnnotation()] != mergeKey {
+			continue
+		}
+		if !httproutePointsToGateway(sibling, gatewayName, gatewayNamespace) {
+			continue
+		}
+
+		ips, err := r.CidrResolver.GetCidrsFromObject(ctx, sibling)
+		if err == r.CidrResolver.AnnotationNotFoundError() {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, ip := range ips {
+			if _, seen := seenIPs[ip]; !seen {
+				seenIPs[ip] = struct{}{}
+				mergedIPs = append(mergedIPs, ip)
+			}
+		}
+		for _, h := range sibling.Spec.Hostnames {
+			host := string(h)
+			if _, seen := seenHosts[host]; !seen {
+				seenHosts[host] = struct{}{}
+				mergedHosts = append(mergedHosts, host)
+			}
 		}
 	}
 
-	_, err = ctrl.CreateOrUpdate(ctx, r.Client, generatedAuthorizationPolicy, func() error {
-		generatedAuthorizationPolicy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+	if len(mergedIPs) == 0 {
+		log.Infof("No CIDRs found for merge group %q → gateway %s/%s, skipping", mergeKey, gatewayNamespace, gatewayName)
+		return nil
+	}
+
+	policyName := mergeKey
+	if i > 0 {
+		policyName = fmt.Sprintf("%s-%d", mergeKey, i)
+	}
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: gatewayNamespace},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
+		r.applyLabels(policy, "merged", mergeKey)
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
 			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-			Rules:  rules,
+			Rules:  buildAuthorizationRules(mergedIPs, mergedHosts),
 			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-				{
-					Name:  gatewayName,
-					Kind:  "Gateway",
-					Group: "gateway.networking.k8s.io",
-				},
+				{Name: gatewayName, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
 			},
 		}
 		return nil
 	})
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", targetNamespace, policyName, httproute.GetName())
+	log.Infof("Merged AuthorizationPolicy %s/%s created/updated for merge group %q", gatewayNamespace, policyName, mergeKey)
+	return nil
+}
 
-	return ctrl.Result{}, nil
+func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, gatewayNamespace string) bool {
+	for _, ref := range gatewayParentRefs(httproute) {
+		if string(ref.Name) == gatewayName && ref.Namespace != nil && string(*ref.Namespace) == gatewayNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+func buildAuthorizationRules(allowedIPs, hostnames []string) []*istioApiSecurityV1.Rule {
+	rules := []*istioApiSecurityV1.Rule{
+		{
+			From: []*istioApiSecurityV1.Rule_From{
+				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: allowedIPs}},
+			},
+		},
+	}
+	if len(hostnames) > 0 {
+		rules[0].To = []*istioApiSecurityV1.Rule_To{
+			{Operation: &istioApiSecurityV1.Operation{Hosts: hostnames}},
+		}
+	}
+	return rules
 }
 
 func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {
@@ -138,10 +290,17 @@ func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {
 }
 
 func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
+	r.Prefix = namePrefix
 	annotationPredicate := predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object) },
-		GenericFunc: func(e event.GenericEvent) bool { return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object) },
+		CreateFunc: func(e event.CreateEvent) bool {
+			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.Object)
+		},
 		// Check both old and new: annotation removal must trigger reconcile to clean up the AuthorizationPolicy.
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.ObjectNew) || hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, e.ObjectOld)

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	workqueue "k8s.io/client-go/util/workqueue"
 
 	istioApiSecurityV1 "istio.io/api/security/v1"
 	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
@@ -146,13 +147,6 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 				continue // merge only applies to cross-namespace refs
 			}
 			if err := r.reconcileMergedGateway(ctx, &httproute, ref, mergeKey, i); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Rebuild APs for all other merge keys pointing to the same gateway.
-			// This handles the case where a sibling left this group (changed its merge key):
-			// the sibling's own reconcile triggered us, but the old group's AP still contains
-			// the sibling's stale data — we must rebuild it now.
-			if err := r.reconcileOtherMergeGroupsForGateway(ctx, &httproute, ref, mergeKey); err != nil {
 				return ctrl.Result{}, err
 			}
 			i++
@@ -313,40 +307,6 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 	})
 }
 
-// reconcileOtherMergeGroupsForGateway rebuilds APs for all merge keys other than currentKey
-// that point to the same gateway. This ensures that when a route changes its merge key, the AP
-// for the group it left is immediately updated to remove its stale data.
-func (r *HTTPRouteAllowlistingReconciler) reconcileOtherMergeGroupsForGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, currentKey string) error {
-	gatewayName := string(ref.Name)
-	gatewayNamespace := string(*ref.Namespace)
-
-	allRoutes := &gatewayApiv1.HTTPRouteList{}
-	if err := r.List(ctx, allRoutes); err != nil {
-		return err
-	}
-
-	// Collect distinct merge keys (excluding current) that point to this gateway
-	otherKeys := map[string]struct{}{}
-	for i := range allRoutes.Items {
-		sibling := &allRoutes.Items[i]
-		key := sibling.Annotations[r.mergeAnnotation()]
-		if key == "" || key == currentKey {
-			continue
-		}
-		if httproutePointsToGateway(sibling, gatewayName, gatewayNamespace) {
-			otherKeys[key] = struct{}{}
-		}
-	}
-
-	// Rebuild the AP for each other merge group
-	for key := range otherKeys {
-		if err := r.reconcileMergedGateway(ctx, httproute, ref, key, 0); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {
 	log := log.DefaultLogger.WithContext(ctx)
 	gatewayName := string(ref.Name)
@@ -435,6 +395,34 @@ func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyN
 	return false
 }
 
+// mergeSiblingEnqueuer returns an EventHandler that, when an HTTPRoute's merge annotation
+// changes, enqueues all remaining members of the old merge group so they rebuild their AP
+// without the departed route's stale data.
+func (r *HTTPRouteAllowlistingReconciler) mergeSiblingEnqueuer() handler.EventHandler {
+	return handler.Funcs{
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			oldKey := e.ObjectOld.GetAnnotations()[r.mergeAnnotation()]
+			newKey := e.ObjectNew.GetAnnotations()[r.mergeAnnotation()]
+			if oldKey == newKey || oldKey == "" {
+				return // no merge key change — nothing to do
+			}
+			// Route left merge group oldKey — enqueue all current members so they rebuild
+			routes := &gatewayApiv1.HTTPRouteList{}
+			if err := r.List(ctx, routes); err != nil {
+				return
+			}
+			for _, route := range routes.Items {
+				if route.Annotations[r.mergeAnnotation()] == oldKey {
+					q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+						Namespace: route.Namespace,
+						Name:      route.Name,
+					}})
+				}
+			}
+		},
+	}
+}
+
 func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, gatewayNamespace string) bool {
 	for _, ref := range gatewayParentRefs(httproute) {
 		if string(ref.Name) == gatewayName && ref.Namespace != nil && string(*ref.Namespace) == gatewayNamespace {
@@ -494,7 +482,10 @@ func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nam
 			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation()))).
 		Watches(
 			&ipamv1alpha1.ClusterCIDRs{},
-			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation())))
+			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
+		Watches(
+			&gatewayApiv1.HTTPRoute{},
+			r.mergeSiblingEnqueuer())
 	if namePrefix != "" {
 		build = build.Named(namePrefix + "-httproute")
 	}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -65,7 +65,17 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 
 	httproute := gatewayApiv1.HTTPRoute{}
 	if err := r.Get(ctx, req.NamespacedName, &httproute); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, err
+		}
+		// Route not found — it was deleted or evicted from the cache (e.g. watch-selector label removed).
+		// Clean up any APs that were created for it.
+		for _, writer := range r.L7Writers {
+			if err := writer.DeleteForRoute(ctx, r.managedByValue(), req.Namespace, req.Name); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
 	}
 	log.Infof("HTTPRoute %s being reconciled. Creating/updating writers...", httproute.GetName())
 
@@ -78,7 +88,7 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	if mergeKey := httproute.Annotations[r.mergeAnnotation()]; mergeKey != "" {
 		if err := validateMergeKey(mergeKey); err != nil {
 			log.Errorf("HTTPRoute %s/%s has invalid merge key: %v", httproute.Namespace, httproute.GetName(), err)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 		for _, ref := range parentRefs {
 			gatewayNS := httproute.Namespace // nil Namespace means same namespace as the route
@@ -116,6 +126,11 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			}
 		}
 		return ctrl.Result{}, nil
+	}
+
+	// Route is not in merge mode — clean up any stale merged APs where this route was the last member.
+	if err := r.cleanupOrphanedMergedAPs(ctx, &httproute, parentRefs); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	allowedIps, err := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
@@ -200,6 +215,28 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
+	// Delete stale APs owned by this route that the current reconcile no longer produces
+	// (e.g. rule count reduced, or granularity changed from rule→host).
+	for _, writer := range r.L7Writers {
+		managed, err := writer.ListManaged(ctx, r.managedByValue())
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		for _, obj := range managed {
+			ownerNS := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
+			ownerName := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-name"]
+			if ownerNS != writers.LabelSafe(httproute.Namespace) || ownerName != writers.LabelSafe(httproute.Name) {
+				continue
+			}
+			if writer.IsOrphaned(obj, []gatewayApiv1.HTTPRoute{httproute}) {
+				if err := writer.Delete(ctx, obj); err != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("Deleted stale policy %s/%s for HTTPRoute %s", obj.GetNamespace(), obj.GetName(), httproute.GetName())
+			}
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -239,7 +276,23 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 		}
 		for _, obj := range managed {
 			obj := obj
-			if writer.IsOrphaned(obj, allRoutes.Items) {
+			shouldDelete := writer.IsOrphaned(obj, allRoutes.Items)
+			if !shouldDelete {
+				// Also delete if the owning route exists but lost its allowlist annotation —
+				// the runtime DeleteForRoute would have handled this, but a restart may have missed it.
+				ownerNS := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
+				ownerName := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-name"]
+				for i := range allRoutes.Items {
+					route := &allRoutes.Items[i]
+					if writers.LabelSafe(route.Namespace) == ownerNS && writers.LabelSafe(route.Name) == ownerName {
+						if !hasAllowlistAnnotation(r.CidrResolver.AnnotationPrefix, route) {
+							shouldDelete = true
+						}
+						break
+					}
+				}
+			}
+			if shouldDelete {
 				if err := writer.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
 					log.Errorf("startup cleanup: failed to delete %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
 					continue
@@ -248,6 +301,92 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 			}
 		}
 	}
+}
+
+// cleanupOrphanedMergedAPs checks whether the route just left a merge group as the last member.
+// For each gateway the route is attached to, it looks for a merged AP whose group now has
+// no remaining siblings in the cache — and confirms via APIReader before deleting.
+func (r *HTTPRouteAllowlistingReconciler) cleanupOrphanedMergedAPs(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, parentRefs []gatewayApiv1.ParentReference) error {
+	log := log.DefaultLogger.WithContext(ctx)
+	for _, ref := range parentRefs {
+		gatewayNS := httproute.Namespace
+		if ref.Namespace != nil {
+			gatewayNS = string(*ref.Namespace)
+		}
+		gateway := &gatewayApiv1.Gateway{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return err
+			}
+			continue
+		}
+		gwClass := &gatewayApiv1.GatewayClass{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return err
+			}
+			continue
+		}
+		writer, ok := r.L7Writers[string(gwClass.Spec.ControllerName)]
+		if !ok {
+			continue
+		}
+		mw, ok := writer.(writers.MergeableL7PolicyWriter)
+		if !ok {
+			continue
+		}
+
+		managed, err := mw.ListManaged(ctx, r.managedByValue())
+		if err != nil {
+			return err
+		}
+		for _, obj := range managed {
+			ownerNS := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
+			if ownerNS != "MERGED" {
+				continue
+			}
+			mergeKey := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-name"]
+			if mergeKey == "" || obj.GetNamespace() != gatewayNS {
+				continue
+			}
+			// Check cache: any sibling still in this group?
+			allRoutes := &gatewayApiv1.HTTPRouteList{}
+			if err := r.List(ctx, allRoutes); err != nil {
+				return err
+			}
+			hasSibling := false
+			for _, route := range allRoutes.Items {
+				if route.Annotations[r.mergeAnnotation()] == mergeKey &&
+					httproutePointsToGateway(&route, gateway.Name, gateway.Namespace) {
+					hasSibling = true
+					break
+				}
+			}
+			if hasSibling {
+				continue
+			}
+			// Confirm via direct API read before deleting.
+			confirmed := &gatewayApiv1.HTTPRouteList{}
+			if err := r.APIReader.List(ctx, confirmed); err != nil {
+				return err
+			}
+			for _, route := range confirmed.Items {
+				if route.Annotations[r.mergeAnnotation()] == mergeKey &&
+					httproutePointsToGateway(&route, gateway.Name, gateway.Namespace) {
+					hasSibling = true
+					break
+				}
+			}
+			if hasSibling {
+				continue
+			}
+			if err := mw.DeleteMerged(ctx, gatewayNS, mergeKey); err != nil {
+				return err
+			}
+			log.Infof("Deleted orphaned merged AP %q — no siblings remain in group", mergeKey)
+		}
+	}
+	return nil
 }
 
 func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, writer writers.MergeableL7PolicyWriter, mergeKey string) error {
@@ -268,6 +407,26 @@ func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Con
 			continue
 		}
 		siblings = append(siblings, sibling)
+	}
+
+	if len(siblings) == 0 {
+		// Cache shows no siblings — confirm via direct API read before deleting,
+		// to avoid removing the AP on a dirty cache read (same guard as startup cleanup).
+		confirmed := &gatewayApiv1.HTTPRouteList{}
+		if err := r.APIReader.List(ctx, confirmed); err != nil {
+			return err
+		}
+		for _, route := range confirmed.Items {
+			if route.Annotations[r.mergeAnnotation()] == mergeKey &&
+				httproutePointsToGateway(&route, gateway.Name, gateway.Namespace) {
+				return nil // cache was stale — sibling still exists, skip deletion
+			}
+		}
+		if err := writer.DeleteMerged(ctx, gateway.Namespace, mergeKey); err != nil {
+			return err
+		}
+		log.Infof("Deleted merged AuthorizationPolicy for empty group %q → gateway %s/%s", mergeKey, gateway.Namespace, gateway.Name)
+		return nil
 	}
 
 	if err := writer.ApplyMerged(ctx, gateway, siblings, mergeKey); err != nil {

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -148,6 +148,13 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			if err := r.reconcileMergedGateway(ctx, &httproute, ref, mergeKey, i); err != nil {
 				return ctrl.Result{}, err
 			}
+			// Rebuild APs for all other merge keys pointing to the same gateway.
+			// This handles the case where a sibling left this group (changed its merge key):
+			// the sibling's own reconcile triggered us, but the old group's AP still contains
+			// the sibling's stale data — we must rebuild it now.
+			if err := r.reconcileOtherMergeGroupsForGateway(ctx, &httproute, ref, mergeKey); err != nil {
+				return ctrl.Result{}, err
+			}
 			i++
 		}
 		r.runStartupCleanup(ctx)
@@ -304,6 +311,40 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 			log.Infof("Startup cleanup: deleted orphaned AuthorizationPolicy %s/%s (owner: %s/%s)", ap.Namespace, ap.Name, ownerNS, ownerName)
 		}
 	})
+}
+
+// reconcileOtherMergeGroupsForGateway rebuilds APs for all merge keys other than currentKey
+// that point to the same gateway. This ensures that when a route changes its merge key, the AP
+// for the group it left is immediately updated to remove its stale data.
+func (r *HTTPRouteAllowlistingReconciler) reconcileOtherMergeGroupsForGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, currentKey string) error {
+	gatewayName := string(ref.Name)
+	gatewayNamespace := string(*ref.Namespace)
+
+	allRoutes := &gatewayApiv1.HTTPRouteList{}
+	if err := r.List(ctx, allRoutes); err != nil {
+		return err
+	}
+
+	// Collect distinct merge keys (excluding current) that point to this gateway
+	otherKeys := map[string]struct{}{}
+	for i := range allRoutes.Items {
+		sibling := &allRoutes.Items[i]
+		key := sibling.Annotations[r.mergeAnnotation()]
+		if key == "" || key == currentKey {
+			continue
+		}
+		if httproutePointsToGateway(sibling, gatewayName, gatewayNamespace) {
+			otherKeys[key] = struct{}{}
+		}
+	}
+
+	// Rebuild the AP for each other merge group
+	for key := range otherKeys {
+		if err := r.reconcileMergedGateway(ctx, httproute, ref, key, 0); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,14 +18,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	workqueue "k8s.io/client-go/util/workqueue"
 
-	istioApiSecurityV1 "istio.io/api/security/v1"
-	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
 
@@ -36,65 +36,21 @@ type HTTPRouteAllowlistingReconciler struct {
 	LegacyGroupVersion string
 	Prefix             string
 	CidrResolver       resolvers.CidrResolver
+	L7Writers          writers.L7WriterRegistry
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
-
-type policyTarget struct {
-	namespace      string
-	name           string
-	gatewayName    string
-	crossNamespace bool
-	ref            gatewayApiv1.ParentReference
-}
-
-// policyTargets computes the complete set of AuthorizationPolicies that the non-merge
-// reconcile path would produce for route: one per Gateway parentRef, with namespace and
-// name derived from the cross-namespace flag and index. Single source of truth for AP naming.
-func policyTargets(route *gatewayApiv1.HTTPRoute) []policyTarget {
-	var targets []policyTarget
-	for i, ref := range gatewayParentRefs(route) {
-		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != route.Namespace
-		targetNamespace := route.Namespace
-		baseName := route.Name
-		if crossNamespace {
-			targetNamespace = string(*ref.Namespace)
-			baseName = route.Namespace + "-" + route.Name
-		}
-		name := baseName
-		if i > 0 {
-			name = fmt.Sprintf("%s-%d", baseName, i)
-		}
-		targets = append(targets, policyTarget{
-			namespace:      targetNamespace,
-			name:           name,
-			gatewayName:    string(ref.Name),
-			crossNamespace: crossNamespace,
-			ref:            ref,
-		})
-	}
-	return targets
-}
-
-// gatewayParentRefs returns all parentRefs that target a Gateway.
-func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
-	var refs []gatewayApiv1.ParentReference
-	for _, ref := range httproute.Spec.ParentRefs {
-		if ref.Kind != nil && *ref.Kind != "Gateway" {
-			continue
-		}
-		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
-			continue
-		}
-		refs = append(refs, ref)
-	}
-	return refs
-}
 
 func (r *HTTPRouteAllowlistingReconciler) mergeAnnotation() string {
 	return r.CidrResolver.AnnotationPrefix + "/merge"
+}
+
+func (r *HTTPRouteAllowlistingReconciler) granularityAnnotation() string {
+	return r.CidrResolver.AnnotationPrefix + "/granularity"
 }
 
 func (r *HTTPRouteAllowlistingReconciler) managedByValue() string {
@@ -104,26 +60,6 @@ func (r *HTTPRouteAllowlistingReconciler) managedByValue() string {
 	return "ingress-allowlisting-controller"
 }
 
-// invalidLabelValue matches characters not allowed in k8s label values: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
-var invalidLabelValue = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
-
-func labelSafe(s string) string {
-	v := invalidLabelValue.ReplaceAllString(s, "_")
-	if len(v) > 63 {
-		v = v[:63]
-	}
-	return v
-}
-
-func (r *HTTPRouteAllowlistingReconciler) applyLabels(policy *istiosecurityv1.AuthorizationPolicy, ownerNamespace, ownerName string) {
-	if policy.Labels == nil {
-		policy.Labels = map[string]string{}
-	}
-	policy.Labels["app.kubernetes.io/managed-by"] = r.managedByValue()
-	policy.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"] = labelSafe(ownerNamespace)
-	policy.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"] = labelSafe(ownerName)
-}
-
 func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.DefaultLogger.WithContext(ctx).WithField("httproute", req.NamespacedName)
 
@@ -131,24 +67,53 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	if err := r.Get(ctx, req.NamespacedName, &httproute); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Infof("HTTPRoute %s being reconciled. Creating/updating allowlist...", httproute.GetName())
+	log.Infof("HTTPRoute %s being reconciled. Creating/updating writers...", httproute.GetName())
 
-	parentRefs := gatewayParentRefs(&httproute)
+	parentRefs := gateway.GatewayParentRefs(&httproute)
 	if len(parentRefs) == 0 {
 		log.Infof("HTTPRoute %s has no Gateway parentRefs, skipping", httproute.GetName())
 		return ctrl.Result{}, nil
 	}
 
 	if mergeKey := httproute.Annotations[r.mergeAnnotation()]; mergeKey != "" {
-		i := 0
+		if err := validateMergeKey(mergeKey); err != nil {
+			log.Errorf("HTTPRoute %s/%s has invalid merge key: %v", httproute.Namespace, httproute.GetName(), err)
+			return ctrl.Result{}, err
+		}
 		for _, ref := range parentRefs {
-			if ref.Namespace == nil || string(*ref.Namespace) == httproute.Namespace {
-				continue // merge only applies to cross-namespace refs
+			gatewayNS := httproute.Namespace // nil Namespace means same namespace as the route
+			if ref.Namespace != nil {
+				gatewayNS = string(*ref.Namespace)
 			}
-			if err := r.reconcileMergedGateway(ctx, &httproute, ref, mergeKey, i); err != nil {
+			gateway := &gatewayApiv1.Gateway{}
+			if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("gateway %s/%s not found, skipping parentRef", gatewayNS, ref.Name)
+				continue
+			}
+			gwClass := &gatewayApiv1.GatewayClass{}
+			if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("GatewayClass %s not found, skipping parentRef", gateway.Spec.GatewayClassName)
+				continue
+			}
+			writer, ok := r.L7Writers[string(gwClass.Spec.ControllerName)]
+			if !ok {
+				log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
+				continue
+			}
+			mw, ok := writer.(writers.MergeableL7PolicyWriter)
+			if !ok {
+				log.Infof("writer for controller %s does not support merge, skipping", gwClass.Spec.ControllerName)
+				continue
+			}
+			if err := r.reconcileMergedGateway(ctx, &httproute, gateway, mw, mergeKey); err != nil {
 				return ctrl.Result{}, err
 			}
-			i++
 		}
 		return ctrl.Result{}, nil
 	}
@@ -166,35 +131,67 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		hostnames = append(hostnames, string(h))
 	}
 
-	rules := buildAuthorizationRules(allowedIps, hostnames)
+	granularity := httproute.Annotations[r.granularityAnnotation()]
 
-	for _, pt := range policyTargets(&httproute) {
-		policy := &istiosecurityv1.AuthorizationPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: pt.name, Namespace: pt.namespace},
+	for _, ref := range parentRefs {
+		gatewayNS := httproute.Namespace
+		if ref.Namespace != nil {
+			gatewayNS = string(*ref.Namespace)
 		}
-		_, err = ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
-			if !pt.crossNamespace {
-				// Same-namespace: owner reference enables automatic GC when the HTTPRoute is deleted.
-				// Cross-namespace owner references are silently stripped by the API server; controller-runtime
-				// rejects them early, so we skip the call entirely.
-				if err := ctrl.SetControllerReference(&httproute, policy, r.Scheme); err != nil {
-					return err
+		gateway := &gatewayApiv1.Gateway{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return ctrl.Result{}, err
+			}
+			log.Infof("gateway %s/%s not found, skipping parentRef", gatewayNS, ref.Name)
+			continue
+		}
+		gwClass := &gatewayApiv1.GatewayClass{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return ctrl.Result{}, err
+			}
+			log.Infof("GatewayClass %s not found, skipping parentRef", gateway.Spec.GatewayClassName)
+			continue
+		}
+		writer, ok := r.L7Writers[string(gwClass.Spec.ControllerName)]
+		if !ok {
+			log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
+			continue
+		}
+
+		// Collect per-rule paths using the writer's translation (if it implements PathTranslator).
+		var rulePaths [][]string
+		if granularity == "" || granularity == "rule" {
+			rulePaths = make([][]string, len(httproute.Spec.Rules))
+			for i, rule := range httproute.Spec.Rules {
+				rulePaths[i] = translatePaths(writer, rule.Matches)
+			}
+		}
+
+		switch granularity {
+		case "host":
+			// One AP per route, host-matched, no path restriction.
+			if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.Infof("policy (host) created/updated for HTTPRoute %s → gateway %s/%s", httproute.GetName(), gateway.Namespace, gateway.Name)
+		default:
+			// granularity=rule (default): one AP per HTTPRoute rule.
+			for ruleIdx, paths := range rulePaths {
+				if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, paths); err != nil {
+					return ctrl.Result{}, err
 				}
+				log.Infof("policy (rule) created/updated for HTTPRoute %s rule %d → gateway %s/%s", httproute.GetName(), ruleIdx, gateway.Namespace, gateway.Name)
 			}
-			r.applyLabels(policy, httproute.Namespace, httproute.Name)
-			policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-				Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-				Rules:  rules,
-				TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-					{Name: pt.gatewayName, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
-				},
+			// Fallback: HTTPRoute with no rules — single AP, no path restriction.
+			if len(rulePaths) == 0 {
+				if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil); err != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("policy (rule/fallback) created/updated for HTTPRoute %s → gateway %s/%s", httproute.GetName(), gateway.Namespace, gateway.Name)
 			}
-			return nil
-		})
-		if err != nil {
-			return ctrl.Result{}, err
 		}
-		log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", pt.namespace, pt.name, httproute.GetName())
 	}
 
 	return ctrl.Result{}, nil
@@ -214,193 +211,64 @@ func cleanupRunnable(mgr ctrl.Manager, r *HTTPRouteAllowlistingReconciler) manag
 
 // runStartupCleanup lists all APs managed by this controller, checks whether the owning
 // HTTPRoute still exists and would still produce that AP, and deletes any that are orphaned.
-// This handles APs left behind by previous controller runs.
 func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context) {
-	{
-		log := log.DefaultLogger.WithContext(ctx)
-		log.Infof("Running post-startup orphan cleanup for managed AuthorizationPolicies")
+	log := log.DefaultLogger.WithContext(ctx)
+	log.Infof("Running post-startup orphan cleanup for managed AuthorizationPolicies")
 
-		existing := &istiosecurityv1.AuthorizationPolicyList{}
-		if err := r.List(ctx, existing, client.MatchingLabels{
-			"app.kubernetes.io/managed-by": r.managedByValue(),
-		}); err != nil {
-			log.Errorf("startup cleanup: failed to list AuthorizationPolicies: %v", err)
-			return
-		}
+	allRoutes := &gatewayApiv1.HTTPRouteList{}
+	if err := r.APIReader.List(ctx, allRoutes); err != nil {
+		log.Errorf("startup cleanup: failed to list HTTPRoutes: %v", err)
+		return
+	}
 
-		// Safety check: list all HTTPRoutes once upfront. If the list call fails or returns
-		// empty while we have managed APs, the API server or cache may be in a degraded state.
-		// Abort rather than risk deleting valid APs based on a dirty read.
-		allRoutes := &gatewayApiv1.HTTPRouteList{}
-		if err := r.List(ctx, allRoutes); err != nil {
-			log.Errorf("startup cleanup: failed to list HTTPRoutes, aborting to avoid dirty-read deletions: %v", err)
-			return
+	for _, writer := range r.L7Writers {
+		managed, err := writer.ListManaged(ctx, r.managedByValue())
+		if err != nil {
+			log.Errorf("startup cleanup: failed to list managed policies: %v", err)
+			continue
 		}
-		if len(allRoutes.Items) == 0 && len(existing.Items) > 0 {
+		if len(allRoutes.Items) == 0 && len(managed) > 0 {
 			log.Infof("startup cleanup: no HTTPRoutes found but managed APs exist — skipping to avoid dirty-read deletions")
-			return
+			continue
 		}
-
-		for _, ap := range existing.Items {
-			ap := ap
-			ownerNS := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
-			ownerName := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"]
-
-			if ownerNS == "merged" {
-				// Merge-mode AP: first check the cache (fast path); if not found there, confirm
-				// via direct API server read to rule out label-selector filtering.
-				found := false
-				for i := range allRoutes.Items {
-					if allRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
-						found = true
-						break
-					}
-				}
-				if found {
+		for _, obj := range managed {
+			obj := obj
+			if writer.IsOrphaned(obj, allRoutes.Items) {
+				if err := writer.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+					log.Errorf("startup cleanup: failed to delete %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
 					continue
 				}
-				// Cache returned nothing — confirm via API server before deleting
-				directRoutes := &gatewayApiv1.HTTPRouteList{}
-				if err := r.APIReader.List(ctx, directRoutes); err != nil {
-					log.Errorf("startup cleanup: API reader failed to list HTTPRoutes: %v", err)
-					return
-				}
-				for i := range directRoutes.Items {
-					if directRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
-						found = true
-						break
-					}
-				}
-				if found {
-					continue
-				}
-			} else {
-				// Normal AP: check cache first; if the route is absent from cache, confirm via
-				// direct API server read — it may simply be outside the label selector.
-				route := &gatewayApiv1.HTTPRoute{}
-				err := r.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, route)
-				if client.IgnoreNotFound(err) != nil {
-					log.Errorf("startup cleanup: failed to get HTTPRoute %s/%s: %v", ownerNS, ownerName, err)
-					return
-				}
-				if err == nil && route.Annotations[r.mergeAnnotation()] == "" {
-					// Route is in cache and not in merge mode — check it still produces this AP
-					if routeProducesPolicy(route, ap.Namespace, ap.Name) {
-						continue
-					}
-				}
-				if err != nil {
-					// Not in cache — confirm via API server before deleting
-					directRoute := &gatewayApiv1.HTTPRoute{}
-					directErr := r.APIReader.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, directRoute)
-					if client.IgnoreNotFound(directErr) != nil {
-						log.Errorf("startup cleanup: API reader failed to get HTTPRoute %s/%s: %v", ownerNS, ownerName, directErr)
-						return
-					}
-					if directErr == nil {
-						// Route exists on API server but not in cache — outside label selector, keep AP
-						continue
-					}
-					// Confirmed 404 on API server — truly gone, fall through to delete
-				}
-				// Falls through if: confirmed gone, switched to merge, or no longer produces this AP
+				log.Infof("Startup cleanup: deleted orphaned policy %s/%s", obj.GetNamespace(), obj.GetName())
 			}
-
-			if err := r.Delete(ctx, ap); client.IgnoreNotFound(err) != nil {
-				log.Errorf("startup cleanup: failed to delete orphaned AP %s/%s: %v", ap.Namespace, ap.Name, err)
-				return
-			}
-			log.Infof("Startup cleanup: deleted orphaned AuthorizationPolicy %s/%s (owner: %s/%s)", ap.Namespace, ap.Name, ownerNS, ownerName)
 		}
 	}
 }
 
-func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {
+func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, writer writers.MergeableL7PolicyWriter, mergeKey string) error {
 	log := log.DefaultLogger.WithContext(ctx)
-	gatewayName := string(ref.Name)
-	gatewayNamespace := string(*ref.Namespace)
 
 	allRoutes := &gatewayApiv1.HTTPRouteList{}
 	if err := r.List(ctx, allRoutes); err != nil {
 		return err
 	}
 
-	seenIPs := map[string]struct{}{}
-	seenHosts := map[string]struct{}{}
-	var mergedIPs, mergedHosts []string
-
-	for i := range allRoutes.Items {
-		sibling := &allRoutes.Items[i]
+	var siblings []*gatewayApiv1.HTTPRoute
+	for idx := range allRoutes.Items {
+		sibling := &allRoutes.Items[idx]
 		if sibling.Annotations[r.mergeAnnotation()] != mergeKey {
 			continue
 		}
-		if !httproutePointsToGateway(sibling, gatewayName, gatewayNamespace) {
+		if !httproutePointsToGateway(sibling, gateway.Name, gateway.Namespace) {
 			continue
 		}
-
-		ips, err := r.CidrResolver.GetCidrsFromObject(ctx, sibling)
-		if err == r.CidrResolver.AnnotationNotFoundError() {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		for _, ip := range ips {
-			if _, seen := seenIPs[ip]; !seen {
-				seenIPs[ip] = struct{}{}
-				mergedIPs = append(mergedIPs, ip)
-			}
-		}
-		for _, h := range sibling.Spec.Hostnames {
-			host := string(h)
-			if _, seen := seenHosts[host]; !seen {
-				seenHosts[host] = struct{}{}
-				mergedHosts = append(mergedHosts, host)
-			}
-		}
+		siblings = append(siblings, sibling)
 	}
 
-	if len(mergedIPs) == 0 {
-		log.Infof("No CIDRs found for merge group %q → gateway %s/%s, skipping", mergeKey, gatewayNamespace, gatewayName)
-		return nil
-	}
-
-	policyName := mergeKey
-	if i > 0 {
-		policyName = fmt.Sprintf("%s-%d", mergeKey, i)
-	}
-	policy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: gatewayNamespace},
-	}
-	_, err := ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
-		r.applyLabels(policy, "merged", mergeKey)
-		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-			Rules:  buildAuthorizationRules(mergedIPs, mergedHosts),
-			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-				{Name: gatewayName, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
-			},
-		}
-		return nil
-	})
-	if err != nil {
+	if err := writer.ApplyMerged(ctx, gateway, siblings, mergeKey); err != nil {
 		return err
 	}
-	log.Infof("Merged AuthorizationPolicy %s/%s created/updated for merge group %q", gatewayNamespace, policyName, mergeKey)
+	log.Infof("Merged AuthorizationPolicy created/updated for merge group %q → gateway %s/%s", mergeKey, gateway.Namespace, gateway.Name)
 	return nil
-}
-
-// routeProducesPolicy reports whether the non-merge reconcile path for route would generate
-// an AuthorizationPolicy at the given {namespace, name}. Used by startup cleanup to decide
-// whether an existing AP is still valid or has become orphaned (e.g. parentRef removed,
-// route switched to merge mode, or index shift after reordering parentRefs).
-func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
-	for _, pt := range policyTargets(route) {
-		if pt.namespace == policyNamespace && pt.name == policyName {
-			return true
-		}
-	}
-	return false
 }
 
 // mergeSiblingEnqueuer returns an EventHandler that, when an HTTPRoute's merge annotation
@@ -432,28 +300,47 @@ func (r *HTTPRouteAllowlistingReconciler) mergeSiblingEnqueuer() handler.EventHa
 }
 
 func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, gatewayNamespace string) bool {
-	for _, ref := range gatewayParentRefs(httproute) {
-		if string(ref.Name) == gatewayName && ref.Namespace != nil && string(*ref.Namespace) == gatewayNamespace {
+	for _, ref := range gateway.GatewayParentRefs(httproute) {
+		if string(ref.Name) != gatewayName {
+			continue
+		}
+		// nil Namespace means same namespace as the route — resolve it before comparing.
+		refNS := httproute.Namespace
+		if ref.Namespace != nil {
+			refNS = string(*ref.Namespace)
+		}
+		if refNS == gatewayNamespace {
 			return true
 		}
 	}
 	return false
 }
 
-func buildAuthorizationRules(allowedIPs, hostnames []string) []*istioApiSecurityV1.Rule {
-	rules := []*istioApiSecurityV1.Rule{
-		{
-			From: []*istioApiSecurityV1.Rule_From{
-				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: allowedIPs}},
-			},
-		},
+// validK8sName matches a valid Kubernetes resource name: lowercase alphanumeric and hyphens,
+// must start and end with alphanumeric, max 253 chars.
+var validK8sName = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-\.]{0,251}[a-z0-9])?$`)
+
+// validateMergeKey returns an error if key is not a valid Kubernetes resource name.
+func validateMergeKey(key string) error {
+	if !validK8sName.MatchString(key) {
+		return fmt.Errorf("merge key %q is not a valid Kubernetes resource name: must match [a-z0-9][a-z0-9-.]*[a-z0-9] and be ≤253 chars", key)
 	}
-	if len(hostnames) > 0 {
-		rules[0].To = []*istioApiSecurityV1.Rule_To{
-			{Operation: &istioApiSecurityV1.Operation{Hosts: hostnames}},
+	return nil
+}
+
+// translatePaths delegates path translation to the writer if it implements PathTranslator,
+// falling back to raw path values for writers that handle their own path semantics.
+func translatePaths(writer writers.L7PolicyWriter, matches []gatewayApiv1.HTTPRouteMatch) []string {
+	if pt, ok := writer.(writers.PathTranslator); ok {
+		return pt.TranslatePaths(matches)
+	}
+	var paths []string
+	for _, match := range matches {
+		if match.Path != nil && match.Path.Value != nil {
+			paths = append(paths, *match.Path.Value)
 		}
 	}
-	return rules
+	return paths
 }
 
 func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {
@@ -512,7 +399,7 @@ func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nam
 		build = build.Named(namePrefix + "-httproute")
 	}
 	if r.LegacyGroupVersion != "" {
-		build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
+		build = build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
 			Watches(&ipamv1alpha1_legacy.CIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation())))
 	}
 	return build.Complete(r)
@@ -524,7 +411,7 @@ func newHTTPRoutesFromCIDRFuncMap(c client.Client, annotation string) handler.Ma
 		options := client.ListOptions{
 			Namespace: cidr.GetNamespace(),
 		}
-		err := c.List(context.Background(), httproutes, &options)
+		err := c.List(ctx, httproutes, &options)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,11 +35,48 @@ type HTTPRouteAllowlistingReconciler struct {
 	LegacyGroupVersion string
 	Prefix             string
 	CidrResolver       resolvers.CidrResolver
+	startupCleanupOnce sync.Once
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
+
+type policyTarget struct {
+	namespace      string
+	name           string
+	gatewayName    string
+	crossNamespace bool
+	ref            gatewayApiv1.ParentReference
+}
+
+// policyTargets computes the complete set of AuthorizationPolicies that the non-merge
+// reconcile path would produce for route: one per Gateway parentRef, with namespace and
+// name derived from the cross-namespace flag and index. Single source of truth for AP naming.
+func policyTargets(route *gatewayApiv1.HTTPRoute) []policyTarget {
+	var targets []policyTarget
+	for i, ref := range gatewayParentRefs(route) {
+		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != route.Namespace
+		targetNamespace := route.Namespace
+		baseName := route.Name
+		if crossNamespace {
+			targetNamespace = string(*ref.Namespace)
+			baseName = route.Namespace + "-" + route.Name
+		}
+		name := baseName
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d", baseName, i)
+		}
+		targets = append(targets, policyTarget{
+			namespace:      targetNamespace,
+			name:           name,
+			gatewayName:    string(ref.Name),
+			crossNamespace: crossNamespace,
+			ref:            ref,
+		})
+	}
+	return targets
+}
 
 // gatewayParentRefs returns all parentRefs that target a Gateway.
 func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
@@ -111,6 +149,7 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			}
 			i++
 		}
+		r.runStartupCleanup(ctx)
 		return ctrl.Result{}, nil
 	}
 
@@ -129,29 +168,12 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 
 	rules := buildAuthorizationRules(allowedIps, hostnames)
 
-	for i, ref := range parentRefs {
-		gatewayName := string(ref.Name)
-		targetNamespace := httproute.Namespace
-		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != httproute.Namespace
-
-		baseName := httproute.Name
-		if crossNamespace {
-			targetNamespace = string(*ref.Namespace)
-			baseName = httproute.Namespace + "-" + httproute.Name
-		}
-		policyName := baseName
-		if i > 0 {
-			policyName = fmt.Sprintf("%s-%d", baseName, i)
-		}
-
+	for _, pt := range policyTargets(&httproute) {
 		policy := &istiosecurityv1.AuthorizationPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      policyName,
-				Namespace: targetNamespace,
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: pt.name, Namespace: pt.namespace},
 		}
 		_, err = ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
-			if !crossNamespace {
+			if !pt.crossNamespace {
 				// Same-namespace: owner reference enables automatic GC when the HTTPRoute is deleted.
 				// Cross-namespace owner references are silently stripped by the API server; controller-runtime
 				// rejects them early, so we skip the call entirely.
@@ -164,11 +186,7 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 				Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
 				Rules:  rules,
 				TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-					{
-						Name:  gatewayName,
-						Kind:  "Gateway",
-						Group: "gateway.networking.k8s.io",
-					},
+					{Name: pt.gatewayName, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
 				},
 			}
 			return nil
@@ -176,10 +194,77 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", targetNamespace, policyName, httproute.GetName())
+		log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", pt.namespace, pt.name, httproute.GetName())
 	}
 
+	r.runStartupCleanup(ctx)
+
 	return ctrl.Result{}, nil
+}
+
+// runStartupCleanup runs once after the first reconcile completes. It lists all APs managed by this
+// controller, checks whether the owning HTTPRoute still exists and would still produce that AP,
+// and deletes any that are orphaned. This handles APs left behind by previous controller runs.
+func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context) {
+	r.startupCleanupOnce.Do(func() {
+		log := log.DefaultLogger.WithContext(ctx)
+		log.Infof("Running post-startup orphan cleanup for managed AuthorizationPolicies")
+
+		existing := &istiosecurityv1.AuthorizationPolicyList{}
+		if err := r.List(ctx, existing, client.MatchingLabels{
+			"app.kubernetes.io/managed-by": r.managedByValue(),
+		}); err != nil {
+			log.Errorf("startup cleanup: failed to list AuthorizationPolicies: %v", err)
+			return
+		}
+
+		for _, ap := range existing.Items {
+			ap := ap
+			ownerNS := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
+			ownerName := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"]
+
+			if ownerNS == "merged" {
+				// Merge-mode AP: orphaned if no HTTPRoute with merge=<ownerName> pointing to any gateway exists
+				routes := &gatewayApiv1.HTTPRouteList{}
+				if err := r.List(ctx, routes); err != nil {
+					log.Errorf("startup cleanup: failed to list HTTPRoutes: %v", err)
+					return
+				}
+				found := false
+				for i := range routes.Items {
+					if routes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
+						found = true
+						break
+					}
+				}
+				if found {
+					continue
+				}
+			} else {
+				// Normal AP: orphaned if owner HTTPRoute no longer exists, or has since switched to merge mode,
+				// or no longer produces an AP at this exact {namespace, name}.
+				route := &gatewayApiv1.HTTPRoute{}
+				err := r.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, route)
+				if client.IgnoreNotFound(err) != nil {
+					log.Errorf("startup cleanup: failed to get HTTPRoute %s/%s: %v", ownerNS, ownerName, err)
+					return
+				}
+				if err == nil && route.Annotations[r.mergeAnnotation()] == "" {
+					// Route still exists and is not in merge mode — check it still produces this AP
+					if routeProducesPolicy(route, ap.Namespace, ap.Name) {
+						continue
+					}
+				}
+				// Falls through if: route not found, route switched to merge, or route no longer produces this AP
+			}
+
+			if err := r.Delete(ctx, ap); client.IgnoreNotFound(err) != nil {
+				log.Errorf("startup cleanup: failed to delete orphaned AP %s/%s: %v", ap.Namespace, ap.Name, err)
+				return
+			}
+			log.Infof("Startup cleanup: deleted orphaned AuthorizationPolicy %s/%s (owner: %s/%s)", ap.Namespace, ap.Name, ownerNS, ownerName)
+		}
+	})
 }
 
 func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {
@@ -255,6 +340,19 @@ func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Con
 	}
 	log.Infof("Merged AuthorizationPolicy %s/%s created/updated for merge group %q", gatewayNamespace, policyName, mergeKey)
 	return nil
+}
+
+// routeProducesPolicy reports whether the non-merge reconcile path for route would generate
+// an AuthorizationPolicy at the given {namespace, name}. Used by startup cleanup to decide
+// whether an existing AP is still valid or has become orphaned (e.g. parentRef removed,
+// route switched to merge mode, or index shift after reordering parentRefs).
+func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
+	for _, pt := range policyTargets(route) {
+		if pt.namespace == policyNamespace && pt.name == policyName {
+			return true
+		}
+	}
+	return false
 }
 
 func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, gatewayNamespace string) bool {

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -120,6 +120,12 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 
 	allowedIps, err := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
 	if err == r.CidrResolver.AnnotationNotFoundError() {
+		// Annotation was removed — delete any APs that were previously created for this route.
+		for _, writer := range r.L7Writers {
+			if err := writer.DeleteForRoute(ctx, r.managedByValue(), httproute.Namespace, httproute.Name); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{}, nil
 	}
 	if err != nil {

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
 	istioApiSecurityV1 "istio.io/api/security/v1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
@@ -376,6 +379,93 @@ func TestCidrToHTTPRouteMapper(t *testing.T) {
 		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, cidrResolver.Annotation())(context.Background(), &cidr)
 		assert.Len(t, requests, 1)
 		assert.Equal(t, "test2", requests[0].Name)
+	})
+}
+
+func TestHasAllowlistAnnotation(t *testing.T) {
+	const prefix = "ipam.adevinta.com"
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "local allowlist-group",
+			annotations: map[string]string{prefix + "/allowlist-group": "localnet"},
+			want:        true,
+		},
+		{
+			name:        "cluster-allowlist-group",
+			annotations: map[string]string{prefix + "/cluster-allowlist-group": "globalnet"},
+			want:        true,
+		},
+		{
+			name:        "both annotations",
+			annotations: map[string]string{prefix + "/allowlist-group": "localnet", prefix + "/cluster-allowlist-group": "globalnet"},
+			want:        true,
+		},
+		{
+			name:        "unrelated annotation only",
+			annotations: map[string]string{prefix + "/gateway": "my-gateway"},
+			want:        false,
+		},
+		{
+			name:        "no annotations",
+			annotations: nil,
+			want:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &gatewayApiv1.HTTPRoute{ObjectMeta: v1.ObjectMeta{Annotations: tc.annotations}}
+			assert.Equal(t, tc.want, hasAllowlistAnnotation(prefix, obj))
+		})
+	}
+}
+
+func TestAnnotationPredicate(t *testing.T) {
+	const prefix = "ipam.adevinta.com"
+	withAnnotation := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{prefix + "/allowlist-group": "localnet"}},
+	}
+	withoutAnnotation := &gatewayApiv1.HTTPRoute{ObjectMeta: v1.ObjectMeta{}}
+
+	reconciler := &HTTPRouteAllowlistingReconciler{
+		CidrResolver: resolvers.CidrResolver{AnnotationPrefix: prefix},
+	}
+	// build the predicate the same way SetupWithManager does
+	p := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return hasAllowlistAnnotation(prefix, e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasAllowlistAnnotation(prefix, e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return hasAllowlistAnnotation(prefix, e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasAllowlistAnnotation(reconciler.CidrResolver.AnnotationPrefix, e.ObjectNew) ||
+				hasAllowlistAnnotation(reconciler.CidrResolver.AnnotationPrefix, e.ObjectOld)
+		},
+	}
+
+	t.Run("Create with annotation passes", func(t *testing.T) {
+		assert.True(t, p.Create(event.CreateEvent{Object: withAnnotation}))
+	})
+	t.Run("Create without annotation filtered", func(t *testing.T) {
+		assert.False(t, p.Create(event.CreateEvent{Object: withoutAnnotation}))
+	})
+	t.Run("Delete with annotation passes", func(t *testing.T) {
+		assert.True(t, p.Delete(event.DeleteEvent{Object: withAnnotation}))
+	})
+	t.Run("Delete without annotation filtered", func(t *testing.T) {
+		assert.False(t, p.Delete(event.DeleteEvent{Object: withoutAnnotation}))
+	})
+	t.Run("Update annotation added passes", func(t *testing.T) {
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: withoutAnnotation, ObjectNew: withAnnotation}))
+	})
+	t.Run("Update annotation removed passes (cleanup)", func(t *testing.T) {
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: withAnnotation, ObjectNew: withoutAnnotation}))
+	})
+	t.Run("Update no annotation on either filtered", func(t *testing.T) {
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: withoutAnnotation, ObjectNew: withoutAnnotation}))
 	})
 }
 

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -30,7 +30,9 @@ import (
 func newHTTPRouteReconciler(t *testing.T, k8sClient client.Client, scheme *runtime.Scheme) *HTTPRouteAllowlistingReconciler {
 	t.Helper()
 	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
-	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme}
+	// In tests, APIReader uses the same fake client — no label-selector filtering in tests
+	// so the cache and API reader are equivalent.
+	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, APIReader: k8sClient, CidrResolver: resolver, Scheme: scheme}
 }
 
 // parentRef builds a Gateway ParentReference. Pass ns="" for same-namespace (no Namespace field set).

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -611,6 +611,92 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 	assert.Equal(t, "chaos-monkey", policy.Labels["ipam.adevinta.com/owner-name"])
 }
 
+func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
+	// Scenario: two routes both start with merge=chaos-monkey.
+	// Step 1: reconcile both — AP contains both hostnames.
+	// Step 2: route01 changes to merge=bar — only route01 is reconciled (its annotation changed).
+	//         route00 is NOT reconciled because nothing triggered it.
+	// Bug: the chaos-monkey AP still contains route01's hostname because route00 was never re-reconciled.
+	cidrStaging00 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	cidrStaging01 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"5.6.7.8/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("ns-infra")
+	route00 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "chaos-monkey",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"chaos-monkey.public.ns-staging00.example.com"},
+		},
+	}
+	route01 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "chaos-monkey",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"chaos-monkey.public.ns-staging01.example.com"},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// Step 1: reconcile both routes — AP gets both hostnames
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+	}})
+	assert.NoError(t, err)
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
+	}})
+	assert.NoError(t, err)
+
+	// Confirm both hosts are present
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"chaos-monkey.public.ns-staging00.example.com",
+		"chaos-monkey.public.ns-staging01.example.com",
+	}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+
+	// Step 2: route01 changes its merge key to "bar"
+	route01.Annotations["ipam.adevinta.com/merge"] = "bar"
+	assert.NoError(t, k8sClient.Update(context.Background(), route01))
+
+	// Only route01 is reconciled (its annotation changed) — route00 is NOT triggered
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
+	}})
+	assert.NoError(t, err)
+
+	// Bug: chaos-monkey AP still contains route01's hostname because route00 was never re-reconciled
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
+	assert.NoError(t, err)
+	assert.NotContains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
+		"chaos-monkey.public.ns-staging01.example.com",
+		"BUG: route01 left the merge group but its hostname is still in the chaos-monkey AP")
+}
+
 func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 	sharedCIDR := []string{"1.2.3.4/32", "5.6.7.8/32"}
 	cidrStaging00 := &ipamv1alpha1.CIDRs{

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -1,0 +1,410 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func newHTTPRouteReconciler(t *testing.T, k8sClient client.Client, scheme *runtime.Scheme) *HTTPRouteAllowlistingReconciler {
+	t.Helper()
+	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme}
+}
+
+// cases:
+// v - HTTPRoute has annotations and ipamv1alpha1.CIDRs exists — creates AuthorizationPolicy in same namespace
+// v - HTTPRoute has cluster-allowlist-group annotation — resolves cluster CIDRs
+// v - HTTPRoute has no allowlist annotation — no AuthorizationPolicy created
+// v - HTTPRoute has allowlist annotation but no gateway annotation — no AuthorizationPolicy created
+// v - HTTPRoute has spec.hostnames — To rule included in policy
+// v - HTTPRoute has no spec.hostnames — no To rule in policy
+// v - HTTPRoute has ipam.adevinta.com/namespace annotation — AuthorizationPolicy created in cross namespace
+// v - CIDRs partially not found — policy created with found CIDRs
+// v - ALL CIDRs not found — policy created with deny-all 127.0.0.2/32
+// v - TargetRefs points to gateway named in annotation
+// v - Error from k8s API propagates
+func TestReconcileHTTPRoute(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
+	}
+	globalCidrs := &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "globalnet"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"15.13.12.0/24"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/cluster-allowlist-group": "globalnet",
+			"ipam.adevinta.com/allowlist-group":         "localnet",
+			"ipam.adevinta.com/gateway":                 "my-gateway",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			Hostnames: []gatewayApiv1.Hostname{"example.com", "www.example.com"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, globalCidrs).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+
+	assert.Equal(t, istioApiSecurityV1.AuthorizationPolicy_ALLOW, generatedPolicy.Spec.Action)
+	assert.ElementsMatch(t,
+		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8", "15.13.12.0/24"},
+		generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks,
+	)
+	assert.ElementsMatch(t,
+		[]string{"example.com", "www.example.com"},
+		generatedPolicy.Spec.Rules[0].To[0].Operation.Hosts,
+	)
+	assert.Len(t, generatedPolicy.Spec.TargetRefs, 1)
+	assert.Equal(t, "my-gateway", generatedPolicy.Spec.TargetRefs[0].Name)
+	assert.Equal(t, "Gateway", generatedPolicy.Spec.TargetRefs[0].Kind)
+	assert.Equal(t, "gateway.networking.k8s.io", generatedPolicy.Spec.TargetRefs[0].Group)
+
+	events := &corev1.EventList{}
+	assert.NoError(t, k8sClient.List(context.Background(), events, &client.ListOptions{Namespace: "mynamespace"}))
+	assert.Empty(t, events.Items)
+}
+
+func TestReconcileHTTPRouteNoHostnames(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+			"ipam.adevinta.com/gateway":         "my-gateway",
+		}},
+		// no Spec.Hostnames
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+	assert.Nil(t, generatedPolicy.Spec.Rules[0].To, "To rule should be absent when no hostnames")
+}
+
+func TestReconcileHTTPRouteNoAllowlistAnnotation(t *testing.T) {
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/gateway": "my-gateway",
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.True(t, apierrors.IsNotFound(err), "no AuthorizationPolicy should be created without allowlist annotation")
+}
+
+func TestReconcileHTTPRouteNoGatewayAnnotation(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+			// no gateway annotation
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.True(t, apierrors.IsNotFound(err), "no AuthorizationPolicy should be created without gateway annotation")
+}
+
+func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+			"ipam.adevinta.com/gateway":         "my-gateway",
+			"ipam.adevinta.com/namespace":       "gateway-namespace",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	// Policy should be in gateway-namespace, not mynamespace
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "gateway-namespace"}, generatedPolicy)
+	assert.NoError(t, err, "AuthorizationPolicy should be created in cross-namespace")
+	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+	assert.Equal(t, "my-gateway", generatedPolicy.Spec.TargetRefs[0].Name)
+
+	// Should NOT be in the httproute's namespace
+	notExpectedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, notExpectedPolicy)
+	assert.True(t, apierrors.IsNotFound(err), "AuthorizationPolicy should NOT be in the HTTPRoute namespace")
+}
+
+func TestReconcileHTTPRouteWithClusterCIDR(t *testing.T) {
+	globalNet := &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "globalnet"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
+	}
+	anotherGlobalNet := &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "anotherglobalnet"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"15.13.12.0/24"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/cluster-allowlist-group": "globalnet,anotherglobalnet",
+			"ipam.adevinta.com/gateway":                 "my-gateway",
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, globalNet, anotherGlobalNet).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8", "15.13.12.0/24"},
+		generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks,
+	)
+	assert.Equal(t, istioApiSecurityV1.AuthorizationPolicy_ALLOW, generatedPolicy.Spec.Action)
+	assert.Len(t, generatedPolicy.Spec.TargetRefs, 1)
+	assert.Equal(t, "my-gateway", generatedPolicy.Spec.TargetRefs[0].Name)
+}
+
+func TestReconcileHTTPRoutePartialCIDRsNotFound(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet,notexisting",
+			"ipam.adevinta.com/gateway":         "my-gateway",
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"},
+		generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks,
+	)
+}
+
+func TestReconcileHTTPRouteAllCIDRsNotFound(t *testing.T) {
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "notexisting,alsonotexisting",
+			"ipam.adevinta.com/gateway":         "my-gateway",
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"127.0.0.2/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+
+	events := &corev1.EventList{}
+	k8sClient.List(context.Background(), events, &client.ListOptions{Namespace: "mynamespace"})
+	assert.NotEmpty(t, events.Items)
+	assert.Equal(t, "LookupAllowListingGroup", events.Items[0].Action)
+}
+
+func TestReconcileHTTPRouteTargetRefs(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+			"ipam.adevinta.com/gateway":         "specific-gateway",
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+	assert.Len(t, generatedPolicy.Spec.TargetRefs, 1)
+	ref := generatedPolicy.Spec.TargetRefs[0]
+	assert.Equal(t, "specific-gateway", ref.Name)
+	assert.Equal(t, "Gateway", ref.Kind)
+	assert.Equal(t, "gateway.networking.k8s.io", ref.Group)
+}
+
+func TestReconcileHTTPRouteError(t *testing.T) {
+	k8sClient := &testfunc{WithWatch: fake.NewClientBuilder().WithScheme(extendedScheme).Build()}
+	k8sClient.getfunc = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+		return errors.New("error that is not a NOTFOUND")
+	}
+
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.Error(t, err)
+}
+
+func TestReconcileHTTPRouteWithAnnotationSpaces(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16"}},
+	}
+	dnssourceCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet, dnssource",
+			"ipam.adevinta.com/gateway":         "my-gateway",
+		}},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"192.168.0.0/16", "1.1.1.1/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestCidrToHTTPRouteMapper(t *testing.T) {
+	t.Run("CIDR is being used in the httproute, should return the httproute", func(t *testing.T) {
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet,dnssource"}},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+		cidr := ipamv1alpha1.CIDRs{
+			ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		}
+		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, "ipam.adevinta.com/allowlist-group")(context.Background(), &cidr)
+		assert.Len(t, requests, 1)
+		assert.Equal(t, "test", requests[0].Name)
+	})
+
+	t.Run("CIDR is not being used in the httproute, should return an empty list", func(t *testing.T) {
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "dnssource"}},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+		cidr := ipamv1alpha1.CIDRs{
+			ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		}
+		cidrResolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, cidrResolver.Annotation())(context.Background(), &cidr)
+		assert.Len(t, requests, 0)
+	})
+
+	t.Run("One CIDR is being used in one httproute, should return just that one", func(t *testing.T) {
+		httproute1 := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace"},
+		}
+		httproute2 := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "test2", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "dnssource"}},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute1, httproute2).Build()
+		cidr := ipamv1alpha1.CIDRs{
+			ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
+		}
+		cidrResolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, cidrResolver.Annotation())(context.Background(), &cidr)
+		assert.Len(t, requests, 1)
+		assert.Equal(t, "test2", requests[0].Name)
+	})
+}
+
+func TestClusterCidrToHTTPRouteMapper(t *testing.T) {
+	t.Run("ClusterCIDR is being used in the httproute, should return the httproute", func(t *testing.T) {
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/cluster-allowlist-group": "localnet,dnssource"}},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+		cidr := ipamv1alpha1.ClusterCIDRs{
+			ObjectMeta: v1.ObjectMeta{Name: "localnet"},
+		}
+		cidrResolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, cidrResolver.ClusterAnnotation())(context.Background(), &cidr)
+		assert.Len(t, requests, 1)
+		assert.Equal(t, "test", requests[0].Name)
+	})
+
+	t.Run("ClusterCIDR is not being used in the httproute, should return an empty list", func(t *testing.T) {
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/cluster-allowlist-group": "dnssource"}},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+		cidr := ipamv1alpha1.ClusterCIDRs{
+			ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		}
+		cidrResolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, cidrResolver.ClusterAnnotation())(context.Background(), &cidr)
+		assert.Len(t, requests, 0)
+	})
+}
+

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -852,6 +852,65 @@ func TestStartupOrphanCleanup(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestStartupCleanupAbortsOnEmptyHTTPRouteList(t *testing.T) {
+	// Scenario: managed APs exist but the HTTPRoute list returns empty (dirty read / cache not synced).
+	// Cleanup must abort rather than delete all APs.
+	existingAP := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "some-route", Namespace: "mynamespace",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
+				"ipam.adevinta.com/owner-namespace": "mynamespace",
+				"ipam.adevinta.com/owner-name":      "some-route",
+			},
+		},
+	}
+	// No HTTPRoutes in the cluster — simulates dirty read
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(existingAP).Build()
+
+	// Trigger cleanup via a fake reconcile request (route not found → IgnoreNotFound → cleanup fires)
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+	// Inject a route that exists so reconcile doesn't short-circuit before cleanup
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "trigger", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), cidr); err != nil {
+		t.Fatal(err)
+	}
+	if err := k8sClient.Create(context.Background(), httproute); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "trigger", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	// AP whose owner HTTPRoute doesn't exist should NOT be deleted because
+	// the list returned at least one HTTPRoute (the trigger route), so we're past the empty guard.
+	// This test specifically validates the empty-list guard by checking the AP survives
+	// when the list would have been empty (we use a separate reconciler with no routes pre-loaded).
+	reconciler2 := newHTTPRouteReconciler(t,
+		fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(existingAP).Build(),
+		extendedScheme,
+	)
+	// Reconcile a non-existent route — fires cleanup with empty HTTPRoute list
+	_, _ = reconciler2.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "ghost", Namespace: "mynamespace"}})
+
+	surviving := &istiosecurityv1.AuthorizationPolicy{}
+	err = reconciler2.Get(context.Background(), client.ObjectKey{Name: "some-route", Namespace: "mynamespace"}, surviving)
+	assert.NoError(t, err, "AP should NOT be deleted when HTTPRoute list is empty (dirty-read guard)")
+}
+
 func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 	// Scenario: HTTPRoute was cross-namespace without merge → AP named "mynamespace-test" in "gw-ns".
 	// User later adds merge=myapp → new AP named "myapp" in "gw-ns".

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -14,8 +14,11 @@ import (
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,12 +30,33 @@ import (
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+// newIstioGatewayClass creates an Istio GatewayClass with the given name.
+func newIstioGatewayClass(name string) *gatewayApiv1.GatewayClass {
+	return &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: name},
+		Spec: gatewayApiv1.GatewayClassSpec{
+			ControllerName: gatewayApiv1.GatewayController(writers.IstioControllerName),
+		},
+	}
+}
+
+// newTestGateway creates a Gateway with the given name, namespace, and GatewayClassName.
+func newTestGateway(name, namespace, className string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: gatewayApiv1.ObjectName(className)},
+	}
+}
+
 func newHTTPRouteReconciler(t *testing.T, k8sClient client.Client, scheme *runtime.Scheme) *HTTPRouteAllowlistingReconciler {
 	t.Helper()
 	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	l7Writers := writers.L7WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+	}
 	// In tests, APIReader uses the same fake client — no label-selector filtering in tests
 	// so the cache and API reader are equivalent.
-	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, APIReader: k8sClient, CidrResolver: resolver, Scheme: scheme}
+	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, APIReader: k8sClient, CidrResolver: resolver, Scheme: scheme, L7Writers: l7Writers}
 }
 
 // parentRef builds a Gateway ParentReference. Pass ns="" for same-namespace (no Namespace field set).
@@ -84,14 +108,16 @@ func TestReconcileHTTPRoute(t *testing.T) {
 			Hostnames: []gatewayApiv1.Hostname{"example.com", "www.example.com"},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, globalCidrs).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, globalCidrs, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 
 	assert.Equal(t, istioApiSecurityV1.AuthorizationPolicy_ALLOW, generatedPolicy.Spec.Action)
@@ -133,14 +159,16 @@ func TestReconcileHTTPRouteNoHostnames(t *testing.T) {
 			// no Hostnames
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.Nil(t, generatedPolicy.Spec.Rules[0].To, "To rule should be absent when no hostnames")
 }
@@ -203,22 +231,24 @@ func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
 			Hostnames: []gatewayApiv1.Hostname{"example.com"},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "gateway-namespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// Policy should be in gateway-namespace with name = <httproute.Namespace>-<httproute.Name> (single parent, no suffix)
+	// Policy should be in gateway-namespace with name = {gateway}-{route.Namespace}-{route.Name}
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gateway-namespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "gateway-namespace"}, generatedPolicy)
 	assert.NoError(t, err, "AuthorizationPolicy should be created in cross-namespace")
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 	assert.Equal(t, "my-gateway", generatedPolicy.Spec.TargetRefs[0].Name)
 
 	// Should NOT be in the httproute's namespace
 	notExpectedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "mynamespace"}, notExpectedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "mynamespace"}, notExpectedPolicy)
 	assert.True(t, apierrors.IsNotFound(err), "AuthorizationPolicy should NOT be in the HTTPRoute namespace")
 }
 
@@ -241,14 +271,16 @@ func TestReconcileHTTPRouteWithClusterCIDR(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, globalNet, anotherGlobalNet).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, globalNet, anotherGlobalNet, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t,
 		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8", "15.13.12.0/24"},
@@ -274,14 +306,16 @@ func TestReconcileHTTPRoutePartialCIDRsNotFound(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t,
 		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"},
@@ -300,14 +334,16 @@ func TestReconcileHTTPRouteAllCIDRsNotFound(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"127.0.0.2/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 
@@ -332,14 +368,16 @@ func TestReconcileHTTPRouteTargetRefs(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("specific-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "specific-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.Len(t, generatedPolicy.Spec.TargetRefs, 1)
 	ref := generatedPolicy.Spec.TargetRefs[0]
@@ -379,17 +417,109 @@ func TestReconcileHTTPRouteWithAnnotationSpaces(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"192.168.0.0/16", "1.1.1.1/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 }
+
+func newHTTPRouteWithPaths(name, ns, gwName, granularity string, paths ...string) *gatewayApiv1.HTTPRoute {
+	var rules []gatewayApiv1.HTTPRouteRule
+	for _, p := range paths {
+		p := p
+		pathMatch := gatewayApiv1.PathMatchPathPrefix
+		rules = append(rules, gatewayApiv1.HTTPRouteRule{
+			Matches: []gatewayApiv1.HTTPRouteMatch{{
+				Path: &gatewayApiv1.HTTPPathMatch{Type: &pathMatch, Value: &p},
+			}},
+		})
+	}
+	annotations := map[string]string{
+		"ipam.adevinta.com/allowlist-group": "localnet",
+	}
+	if granularity != "" {
+		annotations["ipam.adevinta.com/granularity"] = granularity
+	}
+	return &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: ns, Annotations: annotations},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef(gwName, "")},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+			Rules:     rules,
+		},
+	}
+}
+
+func TestGranularityRule(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.NoError(t, err)
+
+	// One AP per rule: /api and /admin — list all and verify by path content.
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	err = k8sClient.List(context.Background(), apList, client.InNamespace("ns"))
+	require.NoError(t, err)
+	require.Len(t, apList.Items, 2, "expected two APs, one per rule")
+
+	var pathSets [][]string
+	for _, ap := range apList.Items {
+		require.Len(t, ap.Spec.Rules, 1)
+		require.Len(t, ap.Spec.Rules[0].To, 1)
+		pathSets = append(pathSets, ap.Spec.Rules[0].To[0].Operation.Paths)
+		assert.ElementsMatch(t, []string{"example.com"}, ap.Spec.Rules[0].To[0].Operation.Hosts)
+	}
+	assert.ElementsMatch(t, [][]string{
+		{"/api", "/api/*"},
+		{"/admin", "/admin/*"},
+	}, pathSets)
+}
+
+func TestGranularityHost(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "host", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.NoError(t, err)
+
+	// Single AP, host matched, no path restriction
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, ap)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"example.com"}, ap.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Nil(t, ap.Spec.Rules[0].To[0].Operation.Paths, "host granularity must not set paths")
+
+	// No per-rule APs created
+	apRule := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route-api", Namespace: "ns"}, apRule)
+	assert.True(t, apierrors.IsNotFound(err), "granularity=host must not create per-rule APs")
+}
+
 
 func TestGatewayParentRefs(t *testing.T) {
 	gwGroup := gatewayApiv1.Group("gateway.networking.k8s.io")
@@ -400,7 +530,7 @@ func TestGatewayParentRefs(t *testing.T) {
 
 	t.Run("no parentRefs returns empty slice", func(t *testing.T) {
 		hr := &gatewayApiv1.HTTPRoute{}
-		assert.Empty(t, gatewayParentRefs(hr))
+		assert.Empty(t, gateway.GatewayParentRefs(hr))
 	})
 
 	t.Run("explicit kind=Gateway and group matches", func(t *testing.T) {
@@ -409,7 +539,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &gwKind, Name: "gw"},
 			}},
 		}}
-		refs := gatewayParentRefs(hr)
+		refs := gateway.GatewayParentRefs(hr)
 		assert.Len(t, refs, 1)
 		assert.Equal(t, gatewayApiv1.ObjectName("gw"), refs[0].Name)
 	})
@@ -420,7 +550,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Name: "gw"},
 			}},
 		}}
-		assert.Len(t, gatewayParentRefs(hr), 1)
+		assert.Len(t, gateway.GatewayParentRefs(hr), 1)
 	})
 
 	t.Run("non-Gateway kind is skipped", func(t *testing.T) {
@@ -429,7 +559,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &svcKind, Name: "svc"},
 			}},
 		}}
-		assert.Empty(t, gatewayParentRefs(hr))
+		assert.Empty(t, gateway.GatewayParentRefs(hr))
 	})
 
 	t.Run("non-gateway group is skipped", func(t *testing.T) {
@@ -438,7 +568,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &coreGroup, Kind: &gwKind, Name: "gw"},
 			}},
 		}}
-		assert.Empty(t, gatewayParentRefs(hr))
+		assert.Empty(t, gateway.GatewayParentRefs(hr))
 	})
 
 	t.Run("multiple Gateway parentRefs all returned, non-Gateway skipped", func(t *testing.T) {
@@ -449,7 +579,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &gwKind, Name: "second-gw"},
 			}},
 		}}
-		refs := gatewayParentRefs(hr)
+		refs := gateway.GatewayParentRefs(hr)
 		assert.Len(t, refs, 2)
 		assert.Equal(t, gatewayApiv1.ObjectName("first-gw"), refs[0].Name)
 		assert.Equal(t, gatewayApiv1.ObjectName("second-gw"), refs[1].Name)
@@ -461,7 +591,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &gwKind, Name: "gw", Namespace: &ns},
 			}},
 		}}
-		refs := gatewayParentRefs(hr)
+		refs := gateway.GatewayParentRefs(hr)
 		assert.Len(t, refs, 1)
 		assert.Equal(t, &ns, refs[0].Namespace)
 	})
@@ -485,22 +615,25 @@ func TestReconcileHTTPRouteMultipleGateways(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gwInternal := newTestGateway("internal-gateway", "mynamespace", "istio")
+	gwExternal := newTestGateway("external-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gwInternal, gwExternal).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// First gateway: no suffix → "test"
+	// First gateway: AP name = {gateway}-{route} = "internal-gateway-test"
 	policy0 := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, policy0)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "internal-gateway-test", Namespace: "mynamespace"}, policy0)
 	assert.NoError(t, err)
 	assert.Equal(t, "internal-gateway", policy0.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, policy0.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 
-	// Second gateway: suffix "-1" → "test-1"
+	// Second gateway: AP name = {gateway}-{route} = "external-gateway-test"
 	policy1 := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test-1", Namespace: "mynamespace"}, policy1)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "external-gateway-test", Namespace: "mynamespace"}, policy1)
 	assert.NoError(t, err)
 	assert.Equal(t, "external-gateway", policy1.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, policy1.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
@@ -524,34 +657,99 @@ func TestReconcileHTTPRouteMultipleGatewaysCrossNamespace(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gwInternal := newTestGateway("internal-gateway", "mynamespace", "istio")
+	gwExternal := newTestGateway("external-gateway", "gateway-namespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gwInternal, gwExternal).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// First (same-namespace): no suffix → "test"
+	// First (same-namespace): AP name = "internal-gateway-test"
 	sameNsPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, sameNsPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "internal-gateway-test", Namespace: "mynamespace"}, sameNsPolicy)
 	assert.NoError(t, err)
 	assert.Equal(t, "internal-gateway", sameNsPolicy.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, sameNsPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 
-	// Second (cross-namespace): suffix "-1" → "mynamespace-test-1"
+	// Second (cross-namespace): AP name = "external-gateway-mynamespace-test" in gateway-namespace
 	crossNsPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test-1", Namespace: "gateway-namespace"}, crossNsPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "external-gateway-mynamespace-test", Namespace: "gateway-namespace"}, crossNsPolicy)
 	assert.NoError(t, err)
 	assert.Equal(t, "external-gateway", crossNsPolicy.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, crossNsPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 }
 
+func TestValidateMergeKey(t *testing.T) {
+	valid := []string{
+		"chaos-monkey",
+		"myapp",
+		"a",
+		"a1b2c3",
+		"my-service-v2",
+		"my.app.example.com",
+		"api.service.example.com",
+		strings.Repeat("a", 253),
+	}
+	for _, key := range valid {
+		assert.NoError(t, validateMergeKey(key), "expected %q to be valid", key)
+	}
+
+	invalid := []string{
+		"",
+		"MyApp",          // uppercase
+		"my_app",         // underscore
+		"my/app",         // slash
+		"-myapp",         // leading hyphen
+		"myapp-",         // trailing hyphen
+		"my app",         // space
+		strings.Repeat("a", 254), // too long
+	}
+	for _, key := range invalid {
+		assert.Error(t, validateMergeKey(key), "expected %q to be invalid", key)
+	}
+}
+
+func TestReconcileHTTPRouteMergeInvalidKey(t *testing.T) {
+	// A route with an invalid merge key must return an error — not silently create
+	// an AP with an invalid name that the API server would reject opaquely.
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "INVALID_KEY!", // uppercase + special chars
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gw", Namespace: &gwNS},
+			}},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "gw-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.Error(t, err, "invalid merge key must return an error")
+	assert.Contains(t, err.Error(), "INVALID_KEY!")
+}
+
 func TestReconcileHTTPRouteMerge(t *testing.T) {
 	cidrStaging00 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	cidrStaging01 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging01"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"5.6.7.8/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -560,7 +758,7 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -575,7 +773,7 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -587,7 +785,9 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -600,14 +800,24 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err, "merged policy should be created with name = merge key")
 
-	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+	// Two-level grouping: routes with different CIDR sets each get their own Rule.
+	var allIPs, allHosts []string
+	for _, rule := range policy.Spec.Rules {
+		for _, from := range rule.From {
+			allIPs = append(allIPs, from.Source.RemoteIpBlocks...)
+		}
+		for _, to := range rule.To {
+			allHosts = append(allHosts, to.Operation.Hosts...)
+		}
+	}
+	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, allIPs)
 	assert.ElementsMatch(t,
 		[]string{"chaos-monkey.public.ns-staging00.example.com", "chaos-monkey.public.ns-staging01.example.com"},
-		policy.Spec.Rules[0].To[0].Operation.Hosts,
+		allHosts,
 	)
 	assert.Equal(t, "cross-namespace-public", policy.Spec.TargetRefs[0].Name)
 	assert.Equal(t, "ingress-allowlisting-controller", policy.Labels["app.kubernetes.io/managed-by"])
-	assert.Equal(t, "merged", policy.Labels["ipam.adevinta.com/owner-namespace"])
+	assert.Equal(t, "MERGED", policy.Labels["ipam.adevinta.com/owner-namespace"])
 	assert.Equal(t, "chaos-monkey", policy.Labels["ipam.adevinta.com/owner-name"])
 }
 
@@ -618,11 +828,11 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	//         route00 is NOT reconciled because nothing triggered it.
 	// Bug: the chaos-monkey AP still contains route01's hostname because route00 was never re-reconciled.
 	cidrStaging00 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	cidrStaging01 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging01"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"5.6.7.8/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -630,7 +840,7 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -645,7 +855,7 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -657,7 +867,9 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	// Step 1: reconcile both routes — AP gets both hostnames
@@ -670,14 +882,23 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 
-	// Confirm both hosts are present
+	// Confirm both hosts are present (across all rules — two-level grouping gives each CIDR set its own rule).
+	allPolicyHosts := func(p *istiosecurityv1.AuthorizationPolicy) []string {
+		var hosts []string
+		for _, rule := range p.Spec.Rules {
+			for _, to := range rule.To {
+				hosts = append(hosts, to.Operation.Hosts...)
+			}
+		}
+		return hosts
+	}
 	policy := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"chaos-monkey.public.ns-staging00.example.com",
 		"chaos-monkey.public.ns-staging01.example.com",
-	}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	}, allPolicyHosts(policy))
 
 	// Step 2: route01 changes its merge key to "bar"
 	route01.Annotations["ipam.adevinta.com/merge"] = "bar"
@@ -700,10 +921,11 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	// chaos-monkey AP must now only contain route00's hostname
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err)
-	assert.NotContains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
+	allHosts := allPolicyHosts(policy)
+	assert.NotContains(t, allHosts,
 		"chaos-monkey.public.ns-staging01.example.com",
 		"route01 left the merge group — its hostname must not appear in the chaos-monkey AP")
-	assert.Contains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
+	assert.Contains(t, allHosts,
 		"chaos-monkey.public.ns-staging00.example.com",
 		"route00 is still in the merge group — its hostname must be present")
 }
@@ -711,11 +933,11 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 	sharedCIDR := []string{"1.2.3.4/32", "5.6.7.8/32"}
 	cidrStaging00 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: sharedCIDR},
 	}
 	cidrStaging01 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging01"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: sharedCIDR},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -724,7 +946,7 @@ func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "chaos-monkey.public." + ns + ".example.com", Namespace: ns,
 				Annotations: map[string]string{
-					"ipam.adevinta.com/allowlist-group": "allowlist",
+					"ipam.adevinta.com/allowlist-group": "writers",
 					"ipam.adevinta.com/merge":           "chaos-monkey",
 				},
 			},
@@ -735,7 +957,9 @@ func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 			},
 		}
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, makeRoute("ns-staging00"), makeRoute("ns-staging01")).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, makeRoute("ns-staging00"), makeRoute("ns-staging01"), gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -751,7 +975,7 @@ func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 
 func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 	cidr := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -759,7 +983,7 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -775,7 +999,7 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "other-service.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "other-service",
 			},
 		},
@@ -786,7 +1010,9 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 			Hostnames: []gatewayApiv1.Hostname{"other-service.public.ns-staging00.example.com"},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, otherRoute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, otherRoute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -806,7 +1032,7 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 
 func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T) {
 	cidr := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -814,7 +1040,7 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 			},
 		},
 		Spec: gatewayApiv1.HTTPRouteSpec{
@@ -823,7 +1049,9 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 			}},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route).Build()
+	gwClass2 := newIstioGatewayClass("istio")
+	gw2 := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, gwClass2, gw2).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -831,10 +1059,10 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 	}})
 	assert.NoError(t, err)
 
-	// Normal cross-namespace naming: <namespace>-<name>
+	// Normal cross-namespace naming: {gateway}-{routeNS}-{routeName}
 	policy := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{
-		Name:      "ns-staging00-chaos-monkey.public.ns-staging00.example.com",
+		Name:      "cross-namespace-public-ns-staging00-chaos-monkey.public.ns-staging00.example.com",
 		Namespace: "ns-infra",
 	}, policy)
 	assert.NoError(t, err)
@@ -844,6 +1072,69 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 	merged := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, merged)
 	assert.True(t, apierrors.IsNotFound(err), "no merged policy should be created without merge annotation")
+}
+
+func TestReconcileHTTPRouteMergeSameNamespace(t *testing.T) {
+	// Two routes in the same namespace point to a same-namespace gateway (no Namespace on parentRef).
+	// Both carry merge=myapp — the controller must merge them just like it does cross-namespace.
+	cidr0 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "my-ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	route0 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "svc-a", Namespace: "my-ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "myapp",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				parentRef("my-gateway", ""), // no namespace — same-namespace ref
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"svc-a.example.com"},
+		},
+	}
+	route1 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "svc-b", Namespace: "my-ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "myapp",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				parentRef("my-gateway", ""), // no namespace — same-namespace ref
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"svc-b.example.com"},
+		},
+	}
+
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "my-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr0, route0, route1, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "svc-a", Namespace: "my-ns",
+	}})
+	assert.NoError(t, err)
+
+	// Merged AP lives in the same namespace as the gateway (= route namespace here).
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "myapp", Namespace: "my-ns"}, policy)
+	assert.NoError(t, err, "same-namespace merge must create AP named by merge key")
+
+	var allHosts []string
+	for _, rule := range policy.Spec.Rules {
+		for _, to := range rule.To {
+			allHosts = append(allHosts, to.Operation.Hosts...)
+		}
+	}
+	assert.ElementsMatch(t, []string{"svc-a.example.com", "svc-b.example.com"}, allHosts)
+	assert.Equal(t, "my-gateway", policy.Spec.TargetRefs[0].Name)
 }
 
 func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
@@ -863,14 +1154,16 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 				},
 			},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute).Build()
+		gwClass := newIstioGatewayClass("istio")
+		gw := newTestGateway("my-gateway", "mynamespace", "istio")
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
 		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 		assert.NoError(t, err)
 
 		policy := &istiosecurityv1.AuthorizationPolicy{}
-		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, policy)
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, policy)
 		assert.NoError(t, err)
 
 		assert.Len(t, policy.OwnerReferences, 1)
@@ -889,14 +1182,16 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 				},
 			},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute).Build()
+		gwClass := newIstioGatewayClass("istio")
+		gw := newTestGateway("my-gateway", "gateway-namespace", "istio")
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
 		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 		assert.NoError(t, err)
 
 		policy := &istiosecurityv1.AuthorizationPolicy{}
-		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gateway-namespace"}, policy)
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "gateway-namespace"}, policy)
 		assert.NoError(t, err)
 		assert.Empty(t, policy.OwnerReferences, "cross-namespace AP cannot have owner reference")
 	})
@@ -928,7 +1223,9 @@ func TestStartupOrphanCleanup(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, orphan).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("gateway-a", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, orphan, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -944,7 +1241,7 @@ func TestStartupOrphanCleanup(t *testing.T) {
 
 	// Current AP should still exist
 	current := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, current)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "gateway-a-test", Namespace: "mynamespace"}, current)
 	assert.NoError(t, err)
 }
 
@@ -1034,7 +1331,7 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 	// Old AP from before merge was added — owner is the HTTPRoute (still exists!)
 	oldAP := &istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "mynamespace-test", Namespace: "gw-ns",
+			Name: "my-gateway-mynamespace-test", Namespace: "gw-ns",
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
 				"ipam.adevinta.com/owner-namespace": "mynamespace",
@@ -1043,7 +1340,9 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, oldAP).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "gw-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, oldAP, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -1054,13 +1353,66 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 
 	// Old cross-namespace AP should be deleted — route now uses merge mode
 	stale := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gw-ns"}, stale)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "gw-ns"}, stale)
 	assert.True(t, apierrors.IsNotFound(err), "old non-merge AP should be deleted after merge annotation added")
 
 	// New merged AP should exist
 	merged := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "myapp", Namespace: "gw-ns"}, merged)
 	assert.NoError(t, err, "merged AP should exist")
+}
+
+// TestStartupCleanupGranularityHost verifies that an AP created by a granularity=host route
+// (base name, no path suffix) is NOT deleted by startup cleanup — the full reconcile+cleanup
+// loop must recognise it as live.
+func TestStartupCleanupGranularityHost(t *testing.T) {
+	pathMatch := gatewayApiv1.PathMatchPathPrefix
+	pathVal := "/api"
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "localnet",
+				"ipam.adevinta.com/granularity":     "host",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gw", "")},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+			Rules: []gatewayApiv1.HTTPRouteRule{
+				{Matches: []gatewayApiv1.HTTPRouteMatch{
+					{Path: &gatewayApiv1.HTTPPathMatch{Type: &pathMatch, Value: &pathVal}},
+				}},
+			},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// Reconcile creates the AP.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	// AP must be at base name (no path suffix) for granularity=host.
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, ap)
+	require.NoError(t, err, "AP at base name must exist after reconcile")
+	assert.Nil(t, ap.Spec.Rules[0].To[0].Operation.Paths, "granularity=host AP must have no path restriction")
+
+	// Startup cleanup must NOT delete the live AP.
+	reconciler.runStartupCleanup(context.Background())
+
+	surviving := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, surviving)
+	assert.NoError(t, err, "granularity=host AP must survive startup cleanup")
 }
 
 func TestLabelSafe(t *testing.T) {
@@ -1074,31 +1426,36 @@ func TestLabelSafe(t *testing.T) {
 		{"chaos-monkey.public.ns-staging00.example.com", "chaos-monkey.public.ns-staging00.example.com"},
 		{"namespace/name", "namespace_name"},
 		{"foo*bar", "foo_bar"},
-		{"merged", "merged"},
+		{"MERGED", "MERGED"},
 		{strings.Repeat("a", 70), strings.Repeat("a", 63)},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, labelSafe(tc.input), "input: %q", tc.input)
+		assert.Equal(t, tc.want, writers.LabelSafe(tc.input), "input: %q", tc.input)
 	}
 }
 
 func TestAuthorizationPolicyNameMaxLength(t *testing.T) {
 	// Kubernetes resource names are DNS subdomains: max 253 chars.
-	// Namespace max = 63, name max = 63.
-	// Index suffix is only appended for the 2nd+ parentRef (i > 0).
-	// Worst case: cross-namespace, index 99 → <63>-<63>-99 = 63+1+63+1+2 = 130 chars — well under 253.
+	// Namespace max = 63, name max = 63, gateway name max = 63.
+	// Format: {gateway}-{route}                           (same-namespace)
+	//         {gateway}-{routeNS}-{routeName}             (cross-namespace)
+	//         {gateway}-{route}-{pathSafe}                (same-namespace, with path)
+	//         {gateway}-{routeNS}-{routeName}-{pathSafe}  (cross-namespace, with path)
+	// Worst case: cross-namespace with path → 63+1+63+1+63+1+63 = 255, truncation not implemented
+	// but k8s names are limited to 253. In practice gateway/route/NS names are much shorter.
+	maxGW := strings.Repeat("g", 63)
 	maxNS := strings.Repeat("n", 63)
 	maxName := strings.Repeat("a", 63)
 
-	t.Run("same-namespace with suffix stays under 253", func(t *testing.T) {
-		// <name>-<index>  →  63 + 1 + 2 = 66
-		result := fmt.Sprintf("%s-%d", maxName, 99)
+	t.Run("same-namespace stays under 253", func(t *testing.T) {
+		// {gw}-{name}  →  63 + 1 + 63 = 127
+		result := fmt.Sprintf("%s-%s", maxGW, maxName)
 		assert.LessOrEqual(t, len(result), 253)
 	})
 
-	t.Run("cross-namespace with suffix stays under 253", func(t *testing.T) {
-		// <namespace>-<name>-<index>  →  63 + 1 + 63 + 1 + 2 = 130
-		result := fmt.Sprintf("%s-%s-%d", maxNS, maxName, 99)
+	t.Run("cross-namespace stays under 253", func(t *testing.T) {
+		// {gw}-{ns}-{name}  →  63 + 1 + 63 + 1 + 63 = 191
+		result := fmt.Sprintf("%s-%s-%s", maxGW, maxNS, maxName)
 		assert.LessOrEqual(t, len(result), 253)
 	})
 }

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -31,17 +33,33 @@ func newHTTPRouteReconciler(t *testing.T, k8sClient client.Client, scheme *runti
 	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme}
 }
 
+// parentRef builds a Gateway ParentReference. Pass ns="" for same-namespace (no Namespace field set).
+func parentRef(name, ns string) gatewayApiv1.ParentReference {
+	group := gatewayApiv1.Group("gateway.networking.k8s.io")
+	kind := gatewayApiv1.Kind("Gateway")
+	ref := gatewayApiv1.ParentReference{
+		Group: &group,
+		Kind:  &kind,
+		Name:  gatewayApiv1.ObjectName(name),
+	}
+	if ns != "" {
+		namespace := gatewayApiv1.Namespace(ns)
+		ref.Namespace = &namespace
+	}
+	return ref
+}
+
 // cases:
 // v - HTTPRoute has annotations and ipamv1alpha1.CIDRs exists — creates AuthorizationPolicy in same namespace
 // v - HTTPRoute has cluster-allowlist-group annotation — resolves cluster CIDRs
 // v - HTTPRoute has no allowlist annotation — no AuthorizationPolicy created
-// v - HTTPRoute has allowlist annotation but no gateway annotation — no AuthorizationPolicy created
+// v - HTTPRoute has allowlist annotation but no Gateway parentRef — no AuthorizationPolicy created
 // v - HTTPRoute has spec.hostnames — To rule included in policy
 // v - HTTPRoute has no spec.hostnames — no To rule in policy
-// v - HTTPRoute has ipam.adevinta.com/namespace annotation — AuthorizationPolicy created in cross namespace
+// v - HTTPRoute parentRef has a different namespace — AuthorizationPolicy created in that namespace
 // v - CIDRs partially not found — policy created with found CIDRs
 // v - ALL CIDRs not found — policy created with deny-all 127.0.0.2/32
-// v - TargetRefs points to gateway named in annotation
+// v - TargetRefs points to gateway named in parentRef
 // v - Error from k8s API propagates
 func TestReconcileHTTPRoute(t *testing.T) {
 	localnetCidrs := &ipamv1alpha1.CIDRs{
@@ -56,9 +74,11 @@ func TestReconcileHTTPRoute(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/cluster-allowlist-group": "globalnet",
 			"ipam.adevinta.com/allowlist-group":         "localnet",
-			"ipam.adevinta.com/gateway":                 "my-gateway",
 		}},
 		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
 			Hostnames: []gatewayApiv1.Hostname{"example.com", "www.example.com"},
 		},
 	}
@@ -86,6 +106,10 @@ func TestReconcileHTTPRoute(t *testing.T) {
 	assert.Equal(t, "Gateway", generatedPolicy.Spec.TargetRefs[0].Kind)
 	assert.Equal(t, "gateway.networking.k8s.io", generatedPolicy.Spec.TargetRefs[0].Group)
 
+	assert.Equal(t, "ingress-allowlisting-controller", generatedPolicy.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "mynamespace", generatedPolicy.Labels["ipam.adevinta.com/owner-namespace"])
+	assert.Equal(t, "test", generatedPolicy.Labels["ipam.adevinta.com/owner-name"])
+
 	events := &corev1.EventList{}
 	assert.NoError(t, k8sClient.List(context.Background(), events, &client.ListOptions{Namespace: "mynamespace"}))
 	assert.Empty(t, events.Items)
@@ -99,9 +123,13 @@ func TestReconcileHTTPRouteNoHostnames(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "localnet",
-			"ipam.adevinta.com/gateway":         "my-gateway",
 		}},
-		// no Spec.Hostnames
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+			// no Hostnames
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -117,9 +145,12 @@ func TestReconcileHTTPRouteNoHostnames(t *testing.T) {
 
 func TestReconcileHTTPRouteNoAllowlistAnnotation(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
-		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
-			"ipam.adevinta.com/gateway": "my-gateway",
-		}},
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -132,7 +163,7 @@ func TestReconcileHTTPRouteNoAllowlistAnnotation(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "no AuthorizationPolicy should be created without allowlist annotation")
 }
 
-func TestReconcileHTTPRouteNoGatewayAnnotation(t *testing.T) {
+func TestReconcileHTTPRouteNoParentRef(t *testing.T) {
 	localnetCidrs := &ipamv1alpha1.CIDRs{
 		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
@@ -140,8 +171,8 @@ func TestReconcileHTTPRouteNoGatewayAnnotation(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "localnet",
-			// no gateway annotation
 		}},
+		// no ParentRefs
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -151,7 +182,7 @@ func TestReconcileHTTPRouteNoGatewayAnnotation(t *testing.T) {
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
-	assert.True(t, apierrors.IsNotFound(err), "no AuthorizationPolicy should be created without gateway annotation")
+	assert.True(t, apierrors.IsNotFound(err), "no AuthorizationPolicy should be created without a Gateway parentRef")
 }
 
 func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
@@ -162,10 +193,11 @@ func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "localnet",
-			"ipam.adevinta.com/gateway":         "my-gateway",
-			"ipam.adevinta.com/namespace":       "gateway-namespace",
 		}},
 		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "gateway-namespace")},
+			},
 			Hostnames: []gatewayApiv1.Hostname{"example.com"},
 		},
 	}
@@ -175,16 +207,16 @@ func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// Policy should be in gateway-namespace, not mynamespace
+	// Policy should be in gateway-namespace with name = <httproute.Namespace>-<httproute.Name> (single parent, no suffix)
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "gateway-namespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gateway-namespace"}, generatedPolicy)
 	assert.NoError(t, err, "AuthorizationPolicy should be created in cross-namespace")
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 	assert.Equal(t, "my-gateway", generatedPolicy.Spec.TargetRefs[0].Name)
 
 	// Should NOT be in the httproute's namespace
 	notExpectedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, notExpectedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "mynamespace"}, notExpectedPolicy)
 	assert.True(t, apierrors.IsNotFound(err), "AuthorizationPolicy should NOT be in the HTTPRoute namespace")
 }
 
@@ -200,8 +232,12 @@ func TestReconcileHTTPRouteWithClusterCIDR(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/cluster-allowlist-group": "globalnet,anotherglobalnet",
-			"ipam.adevinta.com/gateway":                 "my-gateway",
 		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, globalNet, anotherGlobalNet).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -229,8 +265,12 @@ func TestReconcileHTTPRoutePartialCIDRsNotFound(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "localnet,notexisting",
-			"ipam.adevinta.com/gateway":         "my-gateway",
 		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -251,8 +291,12 @@ func TestReconcileHTTPRouteAllCIDRsNotFound(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "notexisting,alsonotexisting",
-			"ipam.adevinta.com/gateway":         "my-gateway",
 		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -279,8 +323,12 @@ func TestReconcileHTTPRouteTargetRefs(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "localnet",
-			"ipam.adevinta.com/gateway":         "specific-gateway",
 		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("specific-gateway", "")},
+			},
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -322,8 +370,12 @@ func TestReconcileHTTPRouteWithAnnotationSpaces(t *testing.T) {
 	httproute := &gatewayApiv1.HTTPRoute{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/allowlist-group": "localnet, dnssource",
-			"ipam.adevinta.com/gateway":         "my-gateway",
 		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+			},
+		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, httproute).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
@@ -335,6 +387,460 @@ func TestReconcileHTTPRouteWithAnnotationSpaces(t *testing.T) {
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"192.168.0.0/16", "1.1.1.1/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestGatewayParentRefs(t *testing.T) {
+	gwGroup := gatewayApiv1.Group("gateway.networking.k8s.io")
+	gwKind := gatewayApiv1.Kind("Gateway")
+	svcKind := gatewayApiv1.Kind("Service")
+	coreGroup := gatewayApiv1.Group("")
+	ns := gatewayApiv1.Namespace("other-ns")
+
+	t.Run("no parentRefs returns empty slice", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{}
+		assert.Empty(t, gatewayParentRefs(hr))
+	})
+
+	t.Run("explicit kind=Gateway and group matches", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Group: &gwGroup, Kind: &gwKind, Name: "gw"},
+			}},
+		}}
+		refs := gatewayParentRefs(hr)
+		assert.Len(t, refs, 1)
+		assert.Equal(t, gatewayApiv1.ObjectName("gw"), refs[0].Name)
+	})
+
+	t.Run("nil kind and nil group default to Gateway", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw"},
+			}},
+		}}
+		assert.Len(t, gatewayParentRefs(hr), 1)
+	})
+
+	t.Run("non-Gateway kind is skipped", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Group: &gwGroup, Kind: &svcKind, Name: "svc"},
+			}},
+		}}
+		assert.Empty(t, gatewayParentRefs(hr))
+	})
+
+	t.Run("non-gateway group is skipped", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Group: &coreGroup, Kind: &gwKind, Name: "gw"},
+			}},
+		}}
+		assert.Empty(t, gatewayParentRefs(hr))
+	})
+
+	t.Run("multiple Gateway parentRefs all returned, non-Gateway skipped", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Group: &gwGroup, Kind: &svcKind, Name: "not-this"},
+				{Group: &gwGroup, Kind: &gwKind, Name: "first-gw"},
+				{Group: &gwGroup, Kind: &gwKind, Name: "second-gw"},
+			}},
+		}}
+		refs := gatewayParentRefs(hr)
+		assert.Len(t, refs, 2)
+		assert.Equal(t, gatewayApiv1.ObjectName("first-gw"), refs[0].Name)
+		assert.Equal(t, gatewayApiv1.ObjectName("second-gw"), refs[1].Name)
+	})
+
+	t.Run("namespace in parentRef is preserved", func(t *testing.T) {
+		hr := &gatewayApiv1.HTTPRoute{Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Group: &gwGroup, Kind: &gwKind, Name: "gw", Namespace: &ns},
+			}},
+		}}
+		refs := gatewayParentRefs(hr)
+		assert.Len(t, refs, 1)
+		assert.Equal(t, &ns, refs[0].Namespace)
+	})
+}
+
+func TestReconcileHTTPRouteMultipleGateways(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{
+					parentRef("internal-gateway", ""),
+					parentRef("external-gateway", ""),
+				},
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	// First gateway: no suffix → "test"
+	policy0 := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, policy0)
+	assert.NoError(t, err)
+	assert.Equal(t, "internal-gateway", policy0.Spec.TargetRefs[0].Name)
+	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, policy0.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+
+	// Second gateway: suffix "-1" → "test-1"
+	policy1 := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test-1", Namespace: "mynamespace"}, policy1)
+	assert.NoError(t, err)
+	assert.Equal(t, "external-gateway", policy1.Spec.TargetRefs[0].Name)
+	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, policy1.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestReconcileHTTPRouteMultipleGatewaysCrossNamespace(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{
+					parentRef("internal-gateway", ""),                   // same namespace → policy name = "test"
+					parentRef("external-gateway", "gateway-namespace"),  // cross-namespace → policy name = "mynamespace-test"
+				},
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	// First (same-namespace): no suffix → "test"
+	sameNsPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, sameNsPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, "internal-gateway", sameNsPolicy.Spec.TargetRefs[0].Name)
+	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, sameNsPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+
+	// Second (cross-namespace): suffix "-1" → "mynamespace-test-1"
+	crossNsPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test-1", Namespace: "gateway-namespace"}, crossNsPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, "external-gateway", crossNsPolicy.Spec.TargetRefs[0].Name)
+	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, crossNsPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestReconcileHTTPRouteMerge(t *testing.T) {
+	cidrStaging00 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	cidrStaging01 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"5.6.7.8/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("ns-infra")
+	// HTTPRoute names are different (real-world: hostname-based); the annotation value is the merge key and AP name.
+	route00 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "chaos-monkey",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"chaos-monkey.public.ns-staging00.example.com"},
+		},
+	}
+	route01 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "chaos-monkey",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"chaos-monkey.public.ns-staging01.example.com"},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+	}})
+	assert.NoError(t, err)
+
+	// AP name = merge key (first gateway, no suffix)
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
+	assert.NoError(t, err, "merged policy should be created with name = merge key")
+
+	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+	assert.ElementsMatch(t,
+		[]string{"chaos-monkey.public.ns-staging00.example.com", "chaos-monkey.public.ns-staging01.example.com"},
+		policy.Spec.Rules[0].To[0].Operation.Hosts,
+	)
+	assert.Equal(t, "cross-namespace-public", policy.Spec.TargetRefs[0].Name)
+	assert.Equal(t, "ingress-allowlisting-controller", policy.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "merged", policy.Labels["ipam.adevinta.com/owner-namespace"])
+	assert.Equal(t, "chaos-monkey", policy.Labels["ipam.adevinta.com/owner-name"])
+}
+
+func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
+	sharedCIDR := []string{"1.2.3.4/32", "5.6.7.8/32"}
+	cidrStaging00 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: sharedCIDR},
+	}
+	cidrStaging01 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: sharedCIDR},
+	}
+	gwNS := gatewayApiv1.Namespace("ns-infra")
+	makeRoute := func(ns string) *gatewayApiv1.HTTPRoute {
+		return &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "chaos-monkey.public." + ns + ".example.com", Namespace: ns,
+				Annotations: map[string]string{
+					"ipam.adevinta.com/allowlist-group": "allowlist",
+					"ipam.adevinta.com/merge":           "chaos-monkey",
+				},
+			},
+			Spec: gatewayApiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+					{Name: "cross-namespace-public", Namespace: &gwNS},
+				}},
+			},
+		}
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, makeRoute("ns-staging00"), makeRoute("ns-staging01")).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+	}})
+	assert.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, sharedCIDR, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks, "duplicate IPs should not appear twice")
+}
+
+func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("ns-infra")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "chaos-monkey",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"chaos-monkey.public.ns-staging00.example.com"},
+		},
+	}
+	// Different merge key — must produce a separate AP, not be merged into "chaos-monkey"
+	otherRoute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "other-service.public.ns-staging00.example.com", Namespace: "ns-staging00",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "other-service",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"other-service.public.ns-staging00.example.com"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, otherRoute).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+	}})
+	assert.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]string{"chaos-monkey.public.ns-staging00.example.com"},
+		policy.Spec.Rules[0].To[0].Operation.Hosts,
+		"hosts from a different merge key must not be included",
+	)
+}
+
+func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("ns-infra")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-namespace-public", Namespace: &gwNS},
+			}},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+	}})
+	assert.NoError(t, err)
+
+	// Normal cross-namespace naming: <namespace>-<name>
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{
+		Name:      "ns-staging00-chaos-monkey.public.ns-staging00.example.com",
+		Namespace: "ns-infra",
+	}, policy)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"1.2.3.4/32"}, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+
+	// No merged policy under the service name
+	merged := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, merged)
+	assert.True(t, apierrors.IsNotFound(err), "no merged policy should be created without merge annotation")
+}
+
+func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+
+	t.Run("same-namespace policy gets owner reference", func(t *testing.T) {
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "localnet",
+			}},
+			Spec: gatewayApiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+					ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "")},
+				},
+			},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute).Build()
+		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+		assert.NoError(t, err)
+
+		policy := &istiosecurityv1.AuthorizationPolicy{}
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, policy)
+		assert.NoError(t, err)
+
+		assert.Len(t, policy.OwnerReferences, 1)
+		assert.Equal(t, "test", policy.OwnerReferences[0].Name)
+		assert.Equal(t, "HTTPRoute", policy.OwnerReferences[0].Kind)
+	})
+
+	t.Run("cross-namespace policy has no owner reference", func(t *testing.T) {
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "localnet",
+			}},
+			Spec: gatewayApiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+					ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gateway", "gateway-namespace")},
+				},
+			},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute).Build()
+		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+		assert.NoError(t, err)
+
+		policy := &istiosecurityv1.AuthorizationPolicy{}
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gateway-namespace"}, policy)
+		assert.NoError(t, err)
+		assert.Empty(t, policy.OwnerReferences, "cross-namespace AP cannot have owner reference")
+	})
+}
+
+func TestLabelSafe(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"my-route", "my-route"},
+		{"my_route", "my_route"},
+		{"my.route", "my.route"},
+		{"chaos-monkey.public.ns-staging00.example.com", "chaos-monkey.public.ns-staging00.example.com"},
+		{"namespace/name", "namespace_name"},
+		{"foo*bar", "foo_bar"},
+		{"merged", "merged"},
+		{strings.Repeat("a", 70), strings.Repeat("a", 63)},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, labelSafe(tc.input), "input: %q", tc.input)
+	}
+}
+
+func TestAuthorizationPolicyNameMaxLength(t *testing.T) {
+	// Kubernetes resource names are DNS subdomains: max 253 chars.
+	// Namespace max = 63, name max = 63.
+	// Index suffix is only appended for the 2nd+ parentRef (i > 0).
+	// Worst case: cross-namespace, index 99 → <63>-<63>-99 = 63+1+63+1+2 = 130 chars — well under 253.
+	maxNS := strings.Repeat("n", 63)
+	maxName := strings.Repeat("a", 63)
+
+	t.Run("same-namespace with suffix stays under 253", func(t *testing.T) {
+		// <name>-<index>  →  63 + 1 + 2 = 66
+		result := fmt.Sprintf("%s-%d", maxName, 99)
+		assert.LessOrEqual(t, len(result), 253)
+	})
+
+	t.Run("cross-namespace with suffix stays under 253", func(t *testing.T) {
+		// <namespace>-<name>-<index>  →  63 + 1 + 63 + 1 + 2 = 130
+		result := fmt.Sprintf("%s-%s-%d", maxNS, maxName, 99)
+		assert.LessOrEqual(t, len(result), 253)
+	})
 }
 
 func TestCidrToHTTPRouteMapper(t *testing.T) {
@@ -407,7 +913,7 @@ func TestHasAllowlistAnnotation(t *testing.T) {
 		},
 		{
 			name:        "unrelated annotation only",
-			annotations: map[string]string{prefix + "/gateway": "my-gateway"},
+			annotations: map[string]string{"kubernetes.io/some-annotation": "value"},
 			want:        false,
 		},
 		{
@@ -497,4 +1003,3 @@ func TestClusterCidrToHTTPRouteMapper(t *testing.T) {
 		assert.Len(t, requests, 0)
 	})
 }
-

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -719,8 +719,8 @@ func TestValidateMergeKey(t *testing.T) {
 }
 
 func TestReconcileHTTPRouteMergeInvalidKey(t *testing.T) {
-	// A route with an invalid merge key must return an error — not silently create
-	// an AP with an invalid name that the API server would reject opaquely.
+	// A route with an invalid merge key must stop reconciling without error (no requeue)
+	// and must not create any AP — the user must fix the annotation first.
 	cidr := &ipamv1alpha1.CIDRs{
 		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
@@ -746,8 +746,11 @@ func TestReconcileHTTPRouteMergeInvalidKey(t *testing.T) {
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
-	assert.Error(t, err, "invalid merge key must return an error")
-	assert.Contains(t, err.Error(), "INVALID_KEY!")
+	assert.NoError(t, err, "invalid merge key must not requeue — user must fix the annotation")
+
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	require.NoError(t, k8sClient.List(context.Background(), apList))
+	assert.Empty(t, apList.Items, "no AP must be created for an invalid merge key")
 }
 
 func TestReconcileHTTPRouteMerge(t *testing.T) {
@@ -935,6 +938,52 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	assert.Contains(t, allHosts,
 		"chaos-monkey.public.ns-staging00.example.com",
 		"route00 is still in the merge group — its hostname must be present")
+}
+
+// TestReconcileHTTPRouteMergeLastSiblingLeaves verifies that when the last sibling
+// leaves a merge group, the merged AP is deleted — not left orphaned with stale CIDRs.
+func TestReconcileHTTPRouteMergeLastSiblingLeaves(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "my-group",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gw", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "gw-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+	reconciler.APIReader = k8sClient
+
+	// First reconcile — merged AP is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-group", Namespace: "gw-ns"}, policy))
+
+	// Route leaves the merge group.
+	route.Annotations["ipam.adevinta.com/merge"] = ""
+	require.NoError(t, k8sClient.Update(context.Background(), route))
+
+	// Second reconcile — cache now shows no siblings → confirmed via APIReader → AP deleted.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-group", Namespace: "gw-ns"}, policy)
+	assert.True(t, apierrors.IsNotFound(err), "merged AP must be deleted when last sibling leaves the group")
 }
 
 func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
@@ -1252,6 +1301,77 @@ func TestStartupOrphanCleanup(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestStartupCleanupAnnotationRemoved verifies that startup cleanup deletes APs whose
+// owning route still exists but has had its allowlist annotation removed.
+// This covers the case where the annotation was removed while the controller was down,
+// so the runtime DeleteForRoute call never ran.
+func TestStartupCleanupAnnotationRemoved(t *testing.T) {
+	t.Run("same-namespace", func(t *testing.T) {
+		// Route exists but allowlist annotation is gone.
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Namespace: "ns", Name: "my-route"},
+			Spec: gatewayApiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+					ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gw", "")},
+				},
+			},
+		}
+		// AP was created when the annotation was still present.
+		staleAP := &istiosecurityv1.AuthorizationPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "my-gw-my-route", Namespace: "ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
+					"ipam.adevinta.com/owner-namespace": "ns",
+					"ipam.adevinta.com/owner-name":      "my-route",
+				},
+			},
+		}
+		gwClass := newIstioGatewayClass("istio")
+		gw := newTestGateway("my-gw", "ns", "istio")
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, staleAP, gwClass, gw).Build()
+		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+		reconciler.APIReader = k8sClient
+
+		reconciler.runStartupCleanup(context.Background())
+
+		err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, &istiosecurityv1.AuthorizationPolicy{})
+		assert.True(t, apierrors.IsNotFound(err), "AP must be deleted when owning route lost its allowlist annotation")
+	})
+
+	t.Run("cross-namespace", func(t *testing.T) {
+		// Route in ns, gateway in gw-ns — AP lives in gw-ns (no owner ref).
+		httproute := &gatewayApiv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Namespace: "ns", Name: "my-route"},
+			Spec: gatewayApiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+					ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gw", "gw-ns")},
+				},
+			},
+		}
+		staleAP := &istiosecurityv1.AuthorizationPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "my-gw-ns-my-route", Namespace: "gw-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
+					"ipam.adevinta.com/owner-namespace": "ns",
+					"ipam.adevinta.com/owner-name":      "my-route",
+				},
+			},
+		}
+		gwClass := newIstioGatewayClass("istio")
+		gw := newTestGateway("my-gw", "gw-ns", "istio")
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, staleAP, gwClass, gw).Build()
+		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+		reconciler.APIReader = k8sClient
+
+		reconciler.runStartupCleanup(context.Background())
+
+		err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-ns-my-route", Namespace: "gw-ns"}, &istiosecurityv1.AuthorizationPolicy{})
+		assert.True(t, apierrors.IsNotFound(err), "cross-namespace AP must be deleted when owning route lost its allowlist annotation")
+	})
+}
+
 func TestStartupCleanupAbortsOnEmptyHTTPRouteList(t *testing.T) {
 	// Scenario: managed APs exist but the HTTPRoute list returns empty (dirty read / cache not synced).
 	// Cleanup must abort rather than delete all APs.
@@ -1453,10 +1573,9 @@ func TestAuthorizationPolicyNameMaxLength(t *testing.T) {
 	// Namespace max = 63, name max = 63, gateway name max = 63.
 	// Format: {gateway}-{route}                           (same-namespace)
 	//         {gateway}-{routeNS}-{routeName}             (cross-namespace)
-	//         {gateway}-{route}-{pathSafe}                (same-namespace, with path)
-	//         {gateway}-{routeNS}-{routeName}-{pathSafe}  (cross-namespace, with path)
-	// Worst case: cross-namespace with path → 63+1+63+1+63+1+63 = 255, truncation not implemented
-	// but k8s names are limited to 253. In practice gateway/route/NS names are much shorter.
+	//         {gateway}-{route}-{fnv32hex}                (same-namespace, with paths)
+	//         {gateway}-{routeNS}-{routeName}-{fnv32hex}  (cross-namespace, with paths)
+	// Worst case: cross-namespace with paths → 63+1+63+1+63+1+8 = 200, safely under 253.
 	maxGW := strings.Repeat("g", 63)
 	maxNS := strings.Repeat("n", 63)
 	maxName := strings.Repeat("a", 63)
@@ -1706,4 +1825,236 @@ func TestRuleCountReductionDeletesStaleAPs(t *testing.T) {
 	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
 	require.Len(t, apList.Items, 1, "stale /admin AP must be deleted by startup cleanup")
 	assert.Contains(t, apList.Items[0].Spec.Rules[0].To[0].Operation.Paths, "/api", "remaining AP must be for /api")
+}
+
+// TestLabelRemovalDeletesAPs verifies that when an HTTPRoute is evicted from the informer
+// cache (e.g. label common-platform.io/allowlisting removed), the controller deletes any
+// previously-created APs rather than leaving them orphaned.
+// This simulates the watch-selector scenario: the route's label is removed, the route drops
+// out of the cache, and the controller receives a reconcile request for a now-missing route.
+func TestLabelRemovalDeletesAPs(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile — AP is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 1, "AP must exist after first reconcile")
+
+	// Simulate label removal: delete the route from the store so Get returns NotFound.
+	// This mimics the controller-runtime behaviour when a route leaves the label-selector cache.
+	require.NoError(t, k8sClient.Delete(context.Background(), httproute))
+
+	// Reconcile fires for the now-missing route — APs must be cleaned up.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	assert.Empty(t, apList.Items, "AP must be deleted when route is no longer visible to the controller")
+}
+
+// TestRuleCountReductionDeletesStaleAPsAtRuntime verifies that reducing the number of rules
+// in an HTTPRoute immediately cleans up the now-unused per-rule APs during the same reconcile,
+// without needing a restart or startup cleanup.
+func TestRuleCountReductionDeletesStaleAPsAtRuntime(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile — two APs created (one per rule).
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 2, "two APs must exist after first reconcile")
+
+	// Remove /admin rule — route now has only /api.
+	pathMatch := gatewayApiv1.PathMatchPathPrefix
+	apiPath := "/api"
+	httproute.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{
+			Path: &gatewayApiv1.HTTPPathMatch{Type: &pathMatch, Value: &apiPath},
+		}}},
+	}
+	require.NoError(t, k8sClient.Update(context.Background(), httproute))
+
+	// Second reconcile — stale /admin AP must be deleted immediately (no startup cleanup needed).
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 1, "stale /admin AP must be deleted at runtime")
+	assert.Contains(t, apList.Items[0].Spec.Rules[0].To[0].Operation.Paths, "/api", "remaining AP must be for /api")
+}
+
+// TestGranularityChangedRuleToHostDeletesStaleAPs verifies that switching granularity from
+// "rule" to "host" at runtime causes the per-rule APs to be cleaned up immediately.
+func TestGranularityChangedRuleToHostDeletesStaleAPs(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile with granularity=rule — two per-rule APs created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 2, "two per-rule APs must exist")
+
+	// Switch granularity to "host".
+	httproute.Annotations["ipam.adevinta.com/granularity"] = "host"
+	require.NoError(t, k8sClient.Update(context.Background(), httproute))
+
+	// Second reconcile — one host-level AP created, two per-rule APs cleaned up.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 1, "only one host-level AP must remain after granularity switch")
+	assert.Equal(t, "my-gw-my-route", apList.Items[0].Name, "AP must be at base name (host granularity)")
+	assert.Nil(t, apList.Items[0].Spec.Rules[0].To[0].Operation.Paths, "host-level AP must have no path restriction")
+}
+
+// TestReconcileHTTPRouteMultipleGatewayClassesOneUnknown verifies that when an HTTPRoute
+// references two gateways with different GatewayClasses, one registered and one unknown,
+// the controller creates an AP for the registered one and silently skips the unknown one.
+func TestReconcileHTTPRouteMultipleGatewayClassesOneUnknown(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "ns", Name: "my-route", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{
+					parentRef("istio-gw", ""),
+					parentRef("nginx-gw", ""),
+				},
+			},
+		},
+	}
+	istioGwClass := newIstioGatewayClass("istio")
+	nginxGwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "nginx"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: "k8s.io/nginx"},
+	}
+	istioGw := newTestGateway("istio-gw", "ns", "istio")
+	nginxGw := newTestGateway("nginx-gw", "ns", "nginx")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, istioGwClass, nginxGwClass, istioGw, nginxGw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.NoError(t, err)
+
+	// AP should be created for the Istio gateway only.
+	istioAP := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "istio-gw-my-route", Namespace: "ns"}, istioAP)
+	assert.NoError(t, err, "AP must be created for the registered Istio gateway")
+	assert.Equal(t, "istio-gw", istioAP.Spec.TargetRefs[0].Name)
+
+	// No AP should be created for the nginx gateway (no L7 writer registered for it).
+	nginxAP := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "nginx-gw-my-route", Namespace: "ns"}, nginxAP)
+	assert.True(t, apierrors.IsNotFound(err), "no AP should be created for the unregistered nginx gateway")
+}
+
+// TestMergedAPUpdatesWhenSiblingCIDRsChange verifies that when a sibling's CIDRs change,
+// re-reconciling any route in the merge group picks up the updated IPs for all siblings.
+func TestMergedAPUpdatesWhenSiblingCIDRsChange(t *testing.T) {
+	cidr00 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-a"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32"}},
+	}
+	cidr01 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-b"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"2.2.2.2/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route00 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "svc-a", Namespace: "ns-a",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "shared-app",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gw", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"a.example.com"},
+		},
+	}
+	route01 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "svc-b", Namespace: "ns-b",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "shared-app",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gw", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"b.example.com"},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "gw-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr00, cidr01, route00, route01, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// Initial reconcile — merged AP contains both routes' IPs.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "svc-a", Namespace: "ns-a"}})
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "shared-app", Namespace: "gw-ns"}, policy))
+	var allIPs []string
+	for _, rule := range policy.Spec.Rules {
+		for _, from := range rule.From {
+			allIPs = append(allIPs, from.Source.RemoteIpBlocks...)
+		}
+	}
+	assert.ElementsMatch(t, []string{"1.1.1.1/32", "2.2.2.2/32"}, allIPs)
+
+	// Sibling's CIDR changes: ns-b's allowlist now has a different IP.
+	cidr01.Status.CIDRs = []string{"3.3.3.3/32"}
+	require.NoError(t, k8sClient.Update(context.Background(), cidr01))
+
+	// Re-reconcile any route in the group (e.g. triggered by CIDR→HTTPRoute mapper).
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "svc-a", Namespace: "ns-a"}})
+	require.NoError(t, err)
+
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "shared-app", Namespace: "gw-ns"}, policy))
+	allIPs = nil
+	for _, rule := range policy.Spec.Rules {
+		for _, from := range rule.From {
+			allIPs = append(allIPs, from.Source.RemoteIpBlocks...)
+		}
+	}
+	assert.ElementsMatch(t, []string{"1.1.1.1/32", "3.3.3.3/32"}, allIPs, "merged AP must reflect updated sibling CIDRs")
 }

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -803,6 +803,108 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 	})
 }
 
+func TestStartupOrphanCleanup(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/allowlist-group": "localnet",
+		}},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("gateway-a", "")},
+			},
+		},
+	}
+	// AP whose owner HTTPRoute no longer exists — left over from a previous controller run
+	orphan := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "deleted-route", Namespace: "mynamespace",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
+				"ipam.adevinta.com/owner-namespace": "mynamespace",
+				"ipam.adevinta.com/owner-name":      "deleted-route", // HTTPRoute no longer exists
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, orphan).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile triggers the startup cleanup
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	// Orphaned AP (owner HTTPRoute gone) should be deleted
+	deleted := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "deleted-route", Namespace: "mynamespace"}, deleted)
+	assert.True(t, apierrors.IsNotFound(err), "AP whose owner HTTPRoute no longer exists should be deleted")
+
+	// Current AP should still exist
+	current := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, current)
+	assert.NoError(t, err)
+
+	// Second reconcile must NOT re-run the cleanup (sync.Once)
+	// We verify this by checking the reconciler's Once is already consumed — indirect proof via no extra deletes
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+}
+
+func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
+	// Scenario: HTTPRoute was cross-namespace without merge → AP named "mynamespace-test" in "gw-ns".
+	// User later adds merge=myapp → new AP named "myapp" in "gw-ns".
+	// On restart, cleanup should delete the old "mynamespace-test" AP because the HTTPRoute
+	// now has merge=true and would never produce a non-merge AP anymore.
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "mynamespace", Name: "test",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "localnet",
+				"ipam.adevinta.com/merge":           "myapp",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gateway", Namespace: &gwNS},
+			}},
+		},
+	}
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	// Old AP from before merge was added — owner is the HTTPRoute (still exists!)
+	oldAP := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "mynamespace-test", Namespace: "gw-ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
+				"ipam.adevinta.com/owner-namespace": "mynamespace",
+				"ipam.adevinta.com/owner-name":      "test",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, oldAP).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	// Old cross-namespace AP should be deleted — route now uses merge mode
+	stale := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gw-ns"}, stale)
+	assert.True(t, apierrors.IsNotFound(err), "old non-merge AP should be deleted after merge annotation added")
+
+	// New merged AP should exist
+	merged := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "myapp", Namespace: "gw-ns"}, merged)
+	assert.NoError(t, err, "merged AP should exist")
+}
+
 func TestLabelSafe(t *testing.T) {
 	tests := []struct {
 		input string

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"testing"
 
@@ -29,6 +30,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+func fnv32(s string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum32()
+}
 
 // newIstioGatewayClass creates an Istio GatewayClass with the given name.
 func newIstioGatewayClass(name string) *gatewayApiv1.GatewayClass {
@@ -1427,11 +1434,18 @@ func TestLabelSafe(t *testing.T) {
 		{"namespace/name", "namespace_name"},
 		{"foo*bar", "foo_bar"},
 		{"MERGED", "MERGED"},
-		{strings.Repeat("a", 70), strings.Repeat("a", 63)},
+		{strings.Repeat("a", 64), strings.Repeat("a", 54) + fmt.Sprintf("-%08x", fnv32(strings.Repeat("a", 64)))},
+		// two distinct long names must produce different label values (no silent collision)
+		{strings.Repeat("a", 54) + strings.Repeat("x", 10), strings.Repeat("a", 54) + fmt.Sprintf("-%08x", fnv32(strings.Repeat("a", 54)+strings.Repeat("x", 10)))},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.want, writers.LabelSafe(tc.input), "input: %q", tc.input)
 	}
+
+	// Confirm the two long names produce different results.
+	a := writers.LabelSafe(strings.Repeat("a", 54) + strings.Repeat("x", 10))
+	b := writers.LabelSafe(strings.Repeat("a", 54) + strings.Repeat("y", 10))
+	assert.NotEqual(t, a, b, "distinct long names must not collide after LabelSafe")
 }
 
 func TestAuthorizationPolicyNameMaxLength(t *testing.T) {
@@ -1619,4 +1633,77 @@ func TestClusterCidrToHTTPRouteMapper(t *testing.T) {
 		requests := newHTTPRoutesFromCIDRFuncMap(k8sClient, cidrResolver.ClusterAnnotation())(context.Background(), &cidr)
 		assert.Len(t, requests, 0)
 	})
+}
+
+// TestAnnotationRemovalDeletesAPs verifies that removing the allowlist annotation from an HTTPRoute
+// triggers deletion of any previously-created APs rather than leaving them orphaned.
+func TestAnnotationRemovalDeletesAPs(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile — AP is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 1, "AP must exist after first reconcile")
+
+	// Remove the allowlist annotation.
+	httproute.Annotations = map[string]string{}
+	require.NoError(t, k8sClient.Update(context.Background(), httproute))
+
+	// Second reconcile — AP must be deleted.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	assert.Empty(t, apList.Items, "AP must be deleted after allowlist annotation is removed")
+}
+
+// TestRuleCountReductionDeletesStaleAPs verifies that reducing the number of rules in an HTTPRoute
+// causes the now-unused per-rule APs to be cleaned up on the next startup cleanup.
+func TestRuleCountReductionDeletesStaleAPs(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+	reconciler.APIReader = k8sClient
+
+	// First reconcile — two APs created (one per rule).
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 2, "two APs must exist after first reconcile")
+
+	// Remove /admin rule — route now has only /api.
+	pathMatch := gatewayApiv1.PathMatchPathPrefix
+	apiPath := "/api"
+	httproute.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{
+			Path: &gatewayApiv1.HTTPPathMatch{Type: &pathMatch, Value: &apiPath},
+		}}},
+	}
+	require.NoError(t, k8sClient.Update(context.Background(), httproute))
+
+	// Second reconcile — /api AP is updated, /admin AP still exists (not yet cleaned up).
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	// Startup cleanup must remove the stale /admin AP.
+	reconciler.runStartupCleanup(context.Background())
+	require.NoError(t, k8sClient.List(context.Background(), apList, client.InNamespace("ns")))
+	require.Len(t, apList.Items, 1, "stale /admin AP must be deleted by startup cleanup")
+	assert.Contains(t, apList.Items[0].Spec.Rules[0].To[0].Operation.Paths, "/api", "remaining AP must be for /api")
 }

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -683,18 +683,29 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	route01.Annotations["ipam.adevinta.com/merge"] = "bar"
 	assert.NoError(t, k8sClient.Update(context.Background(), route01))
 
-	// Only route01 is reconciled (its annotation changed) — route00 is NOT triggered
+	// route01 is reconciled (its annotation changed to merge=bar)
 	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
 		Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
 	}})
 	assert.NoError(t, err)
 
-	// Bug: chaos-monkey AP still contains route01's hostname because route00 was never re-reconciled
+	// The mergeSiblingEnqueuer watches for merge key changes and enqueues siblings.
+	// In unit tests the event machinery doesn't run, so we simulate it:
+	// route01 changed from chaos-monkey → bar, so route00 (still in chaos-monkey) gets enqueued.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
+	}})
+	assert.NoError(t, err)
+
+	// chaos-monkey AP must now only contain route00's hostname
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err)
 	assert.NotContains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
 		"chaos-monkey.public.ns-staging01.example.com",
-		"BUG: route01 left the merge group but its hostname is still in the chaos-monkey AP")
+		"route01 left the merge group — its hostname must not appear in the chaos-monkey AP")
+	assert.Contains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
+		"chaos-monkey.public.ns-staging00.example.com",
+		"route00 is still in the merge group — its hostname must be present")
 }
 
 func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -931,9 +931,11 @@ func TestStartupOrphanCleanup(t *testing.T) {
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, orphan).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
-	// First reconcile triggers the startup cleanup
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
+
+	// Simulate the startup Runnable firing after cache sync
+	reconciler.runStartupCleanup(context.Background())
 
 	// Orphaned AP (owner HTTPRoute gone) should be deleted
 	deleted := &istiosecurityv1.AuthorizationPolicy{}
@@ -943,11 +945,6 @@ func TestStartupOrphanCleanup(t *testing.T) {
 	// Current AP should still exist
 	current := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, current)
-	assert.NoError(t, err)
-
-	// Second reconcile must NOT re-run the cleanup (sync.Once)
-	// We verify this by checking the reconciler's Once is already consumed — indirect proof via no extra deletes
-	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 }
 
@@ -1002,8 +999,8 @@ func TestStartupCleanupAbortsOnEmptyHTTPRouteList(t *testing.T) {
 		fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(existingAP).Build(),
 		extendedScheme,
 	)
-	// Reconcile a non-existent route — fires cleanup with empty HTTPRoute list
-	_, _ = reconciler2.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "ghost", Namespace: "mynamespace"}})
+	// Directly call cleanup with empty HTTPRoute list (dirty-read guard should abort)
+	reconciler2.runStartupCleanup(context.Background())
 
 	surviving := &istiosecurityv1.AuthorizationPolicy{}
 	err = reconciler2.Get(context.Background(), client.ObjectKey{Name: "some-route", Namespace: "mynamespace"}, surviving)
@@ -1051,6 +1048,9 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
+
+	// Simulate the startup Runnable firing after cache sync
+	reconciler.runStartupCleanup(context.Background())
 
 	// Old cross-namespace AP should be deleted — route now uses merge mode
 	stale := &istiosecurityv1.AuthorizationPolicy{}

--- a/pkg/controllers/internal/gateway.go
+++ b/pkg/controllers/internal/gateway.go
@@ -1,0 +1,27 @@
+// Package gateway provides shared Gateway API helpers used by both the controllers
+// and writers packages. It exists as a separate internal package to break the
+// import cycle: controllers imports writers, so writers cannot import controllers.
+// Any logic that both layers need must live here instead.
+package gateway
+
+import gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+// GatewayParentRefs returns only the parentRefs from an HTTPRoute that target a Gateway,
+// filtering out any other kinds (e.g. Service). Used in two places:
+//   - httproute_controller: to discover which Gateways the route is attached to and
+//     drive the reconcile loop (one AP per gateway).
+//   - istio_l7 (policyTargetsForRoute): to predict the exact AP names the reconcile loop
+//     would produce, so orphan detection can do exact matching without prefix heuristics.
+func GatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
+	var refs []gatewayApiv1.ParentReference
+	for _, ref := range httproute.Spec.ParentRefs {
+		if ref.Kind != nil && *ref.Kind != "Gateway" {
+			continue
+		}
+		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}

--- a/pkg/controllers/internal/gateway.go
+++ b/pkg/controllers/internal/gateway.go
@@ -11,7 +11,8 @@ import gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 //   - httproute_controller: to discover which Gateways the route is attached to and
 //     drive the reconcile loop (one AP per gateway).
 //   - istio_l7 (policyTargetsForRoute): to predict the exact AP names the reconcile loop
-//     would produce, so orphan detection can do exact matching without prefix heuristics.
+//     would produce, so orphan detection can match exactly — works for both same-namespace
+//     and cross-namespace routes (AP namespace differs in each case).
 func GatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
 	var refs []gatewayApiv1.ParentReference
 	for _, ref := range httproute.Spec.ParentRefs {

--- a/pkg/controllers/writers/interfaces.go
+++ b/pkg/controllers/writers/interfaces.go
@@ -1,0 +1,59 @@
+package writers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const IstioControllerName = "istio.io/gateway-controller"
+
+// Permission represents a single Kubernetes RBAC permission required by a writer.
+type Permission struct {
+	Group    string
+	Resource string
+	Verb     string
+}
+
+// PermissionProvider is an optional interface a writer can implement to declare
+// the RBAC permissions it needs. checkRBAC in main.go uses this for preflight checks.
+type PermissionProvider interface {
+	RequiredPermissions() []Permission
+}
+
+// L4PolicyWriter creates gateway-level (L4) allow policies.
+type L4PolicyWriter interface {
+	Apply(ctx context.Context, scheme *runtime.Scheme, gateway *gatewayApiv1.Gateway, ips []string) error
+	Delete(ctx context.Context, gateway *gatewayApiv1.Gateway) error
+}
+
+// L7PolicyWriter creates route-level (L7) allow policies.
+type L7PolicyWriter interface {
+	Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string) error
+	ListManaged(ctx context.Context, managedBy string) ([]client.Object, error)
+	IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool
+	Delete(ctx context.Context, obj client.Object) error
+}
+
+// MergeableL7PolicyWriter is an optional extension of L7PolicyWriter for writers that support
+// merging IPs and hosts from multiple HTTPRoutes into a single shared policy identified by a merge key.
+// Writers that don't support this concept simply don't implement this interface.
+type MergeableL7PolicyWriter interface {
+	L7PolicyWriter
+	ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error
+}
+
+// PathTranslator is an optional interface a writer can implement to control how HTTPRoute path
+// matches are translated into the enforcement-layer path strings passed to Apply.
+// Writers that don't implement this receive raw path values from match.Path.Value.
+type PathTranslator interface {
+	TranslatePaths(matches []gatewayApiv1.HTTPRouteMatch) []string
+}
+
+// L4WriterRegistry maps GatewayClass controllerName to an L4PolicyWriter.
+type L4WriterRegistry map[string]L4PolicyWriter
+
+// L7WriterRegistry maps GatewayClass controllerName to an L7PolicyWriter.
+type L7WriterRegistry map[string]L7PolicyWriter

--- a/pkg/controllers/writers/interfaces.go
+++ b/pkg/controllers/writers/interfaces.go
@@ -47,6 +47,9 @@ type L7PolicyWriter interface {
 type MergeableL7PolicyWriter interface {
 	L7PolicyWriter
 	ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error
+	// DeleteMerged removes the merged policy for the given merge key in the gateway's namespace.
+	// Called when a confirmed-empty sibling list means the merge group no longer exists.
+	DeleteMerged(ctx context.Context, namespace, mergeKey string) error
 }
 
 // PathTranslator is an optional interface a writer can implement to control how HTTPRoute path

--- a/pkg/controllers/writers/interfaces.go
+++ b/pkg/controllers/writers/interfaces.go
@@ -35,6 +35,10 @@ type L7PolicyWriter interface {
 	ListManaged(ctx context.Context, managedBy string) ([]client.Object, error)
 	IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool
 	Delete(ctx context.Context, obj client.Object) error
+	// DeleteForRoute deletes all policies owned by the given route, identified by owner labels.
+	// Called when the allowlist annotation is removed so that existing APs are cleaned up
+	// immediately rather than waiting for the next startup cleanup.
+	DeleteForRoute(ctx context.Context, managedBy, routeNamespace, routeName string) error
 }
 
 // MergeableL7PolicyWriter is an optional extension of L7PolicyWriter for writers that support

--- a/pkg/controllers/writers/istio_l4.go
+++ b/pkg/controllers/writers/istio_l4.go
@@ -1,0 +1,82 @@
+package writers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+// IstioL4Writer creates/deletes Istio AuthorizationPolicies for Gateway-level (L4) allowlisting.
+type IstioL4Writer struct {
+	client client.Client
+}
+
+// NewIstioL4Writer returns a new IstioL4Writer using the provided client.
+func NewIstioL4Writer(c client.Client) *IstioL4Writer {
+	return &IstioL4Writer{client: c}
+}
+
+// RequiredPermissions returns the RBAC permissions needed by this writer.
+func (w *IstioL4Writer) RequiredPermissions() []Permission {
+	return []Permission{
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "get"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "create"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "update"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "delete"},
+	}
+}
+
+// Apply creates or updates an AuthorizationPolicy for the given Gateway and IPs.
+func (w *IstioL4Writer) Apply(ctx context.Context, scheme *runtime.Scheme, gateway *gatewayApiv1.Gateway, ips []string) error {
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+		},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		if err := ctrl.SetControllerReference(gateway, policy, scheme); err != nil {
+			return err
+		}
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules: []*istioApiSecurityV1.Rule{
+				{
+					From: []*istioApiSecurityV1.Rule_From{
+						{
+							Source: &istioApiSecurityV1.Source{
+								RemoteIpBlocks: ips,
+							},
+						},
+					},
+				},
+			},
+			TargetRef: &istioApiTypeV1beta1.PolicyTargetReference{
+				Name:  gateway.Name,
+				Kind:  "Gateway",
+				Group: "gateway.networking.k8s.io",
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// Delete removes the AuthorizationPolicy associated with the given Gateway.
+func (w *IstioL4Writer) Delete(ctx context.Context, gateway *gatewayApiv1.Gateway) error {
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(w.client.Delete(ctx, policy))
+}

--- a/pkg/controllers/writers/istio_l4.go
+++ b/pkg/controllers/writers/istio_l4.go
@@ -59,10 +59,8 @@ func (w *IstioL4Writer) Apply(ctx context.Context, scheme *runtime.Scheme, gatew
 					},
 				},
 			},
-			TargetRef: &istioApiTypeV1beta1.PolicyTargetReference{
-				Name:  gateway.Name,
-				Kind:  "Gateway",
-				Group: "gateway.networking.k8s.io",
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
 			},
 		}
 		return nil

--- a/pkg/controllers/writers/istio_l4_test.go
+++ b/pkg/controllers/writers/istio_l4_test.go
@@ -41,7 +41,7 @@ func TestIstioL4Writer_Apply_CreatesAP(t *testing.T) {
 	ap := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
 	assert.NoError(t, err)
-	assert.Equal(t, "my-gateway", ap.Spec.TargetRef.Name)
+	assert.Equal(t, "my-gateway", ap.Spec.TargetRefs[0].Name)
 }
 
 func TestIstioL4Writer_Apply_SetsOwnerReference(t *testing.T) {

--- a/pkg/controllers/writers/istio_l4_test.go
+++ b/pkg/controllers/writers/istio_l4_test.go
@@ -1,0 +1,95 @@
+package writers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+var istioL4Scheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = gatewayApiv1.Install(s)
+	_ = istiosecurityv1.AddToScheme(s)
+	return s
+}()
+
+func testL4Gateway(name, namespace string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+}
+
+func TestIstioL4Writer_Apply_CreatesAP(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	err := w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"})
+	assert.NoError(t, err)
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-gateway", ap.Spec.TargetRef.Name)
+}
+
+func TestIstioL4Writer_Apply_SetsOwnerReference(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	err := w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"})
+	assert.NoError(t, err)
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
+	assert.NoError(t, err)
+	assert.Len(t, ap.OwnerReferences, 1)
+	assert.Equal(t, "my-gateway", ap.OwnerReferences[0].Name)
+	assert.True(t, *ap.OwnerReferences[0].Controller)
+}
+
+func TestIstioL4Writer_Apply_UpdatesExistingAP(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	assert.NoError(t, w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"}))
+	assert.NoError(t, w.Apply(context.Background(), istioL4Scheme, gw, []string{"192.168.0.0/16"}))
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	assert.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap))
+	assert.Equal(t, []string{"192.168.0.0/16"}, ap.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestIstioL4Writer_Delete_RemovesAP(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	assert.NoError(t, w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"}))
+	assert.NoError(t, w.Delete(context.Background(), gw))
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "AP should be gone")
+}
+
+func TestIstioL4Writer_Delete_ToleratesNotFound(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	assert.NoError(t, w.Delete(context.Background(), gw))
+}

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -27,10 +27,14 @@ import (
 var invalidLabelValue = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
 
 // LabelSafe sanitizes a string for use as a Kubernetes label value.
+// Names longer than 63 chars are truncated to 54 chars and suffixed with
+// "-{fnv32hex}" to stay collision-resistant (same approach as truncateName).
 func LabelSafe(s string) string {
 	v := invalidLabelValue.ReplaceAllString(s, "_")
 	if len(v) > 63 {
-		v = v[:63]
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(v))
+		v = fmt.Sprintf("%s-%08x", v[:54], h.Sum32())
 	}
 	return v
 }
@@ -250,6 +254,24 @@ func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.H
 // Delete removes the given object from the cluster.
 func (w *IstioL7Writer) Delete(ctx context.Context, obj client.Object) error {
 	return client.IgnoreNotFound(w.client.Delete(ctx, obj))
+}
+
+// DeleteForRoute deletes all APs owned by the given route, identified by owner labels.
+func (w *IstioL7Writer) DeleteForRoute(ctx context.Context, managedBy, routeNamespace, routeName string) error {
+	list := &istiosecurityv1.AuthorizationPolicyList{}
+	if err := w.client.List(ctx, list, client.MatchingLabels{
+		"app.kubernetes.io/managed-by":          managedBy,
+		w.annotationPrefix + "/owner-namespace": LabelSafe(routeNamespace),
+		w.annotationPrefix + "/owner-name":      LabelSafe(routeName),
+	}); err != nil {
+		return err
+	}
+	for i := range list.Items {
+		if err := client.IgnoreNotFound(w.client.Delete(ctx, list.Items[i])); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // policyTarget is a single (namespace, name) pair identifying an AuthorizationPolicy.

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -1,0 +1,373 @@
+package writers
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"regexp"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+// invalidLabelValue matches characters not allowed in k8s label values.
+var invalidLabelValue = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
+
+// LabelSafe sanitizes a string for use as a Kubernetes label value.
+func LabelSafe(s string) string {
+	v := invalidLabelValue.ReplaceAllString(s, "_")
+	if len(v) > 63 {
+		v = v[:63]
+	}
+	return v
+}
+
+// IstioL7Writer creates/deletes Istio AuthorizationPolicies for HTTPRoute-level (L7) allowlisting.
+type IstioL7Writer struct {
+	client           client.Client
+	managedBy        string
+	annotationPrefix string
+	cidrResolver     resolvers.CidrResolver
+}
+
+// NewIstioL7Writer returns a new IstioL7Writer.
+func NewIstioL7Writer(c client.Client, managedBy string, cidrResolver resolvers.CidrResolver) *IstioL7Writer {
+	return &IstioL7Writer{
+		client:           c,
+		managedBy:        managedBy,
+		annotationPrefix: cidrResolver.AnnotationPrefix,
+		cidrResolver:     cidrResolver,
+	}
+}
+
+// applyLabels sets standard managed-by and owner labels on the policy.
+func (w *IstioL7Writer) applyLabels(policy *istiosecurityv1.AuthorizationPolicy, ownerNamespace, ownerName string) {
+	if policy.Labels == nil {
+		policy.Labels = map[string]string{}
+	}
+	policy.Labels["app.kubernetes.io/managed-by"] = w.managedBy
+	policy.Labels[w.annotationPrefix+"/owner-namespace"] = LabelSafe(ownerNamespace)
+	policy.Labels[w.annotationPrefix+"/owner-name"] = LabelSafe(ownerName)
+}
+
+// pathSafe converts a URL path to a safe AP name suffix.
+// Encoding: escape "-" as "--", trim surrounding "/", replace remaining "/" with "-".
+// Returns empty string only for "/" (or equivalent all-slash paths).
+// Examples: /admin/users → admin-users, /admin-users → admin--users, /root → root, / → ""
+func pathSafe(path string) string {
+	escaped := strings.ReplaceAll(path, "-", "--")
+	escaped = strings.Trim(escaped, "/")
+	return strings.ReplaceAll(escaped, "/", "-")
+}
+
+// policyName computes the AP name and namespace for a given route+gateway+paths.
+// Format: {gateway.Name}-{route.Name} (same-namespace)
+//
+//	{gateway.Name}-{route.Namespace}-{route.Name} (cross-namespace, AP lives in gateway's namespace)
+//
+// When paths is non-empty, a path-safe suffix is appended so each HTTPRoute rule gets its own AP.
+func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, paths []string) (name, namespace string, crossNamespace bool) {
+	crossNamespace = gateway.Namespace != route.Namespace
+	namespace = route.Namespace
+	baseName := gateway.Name + "-" + route.Name
+	if crossNamespace {
+		namespace = gateway.Namespace
+		baseName = gateway.Name + "-" + route.Namespace + "-" + route.Name
+	}
+	name = baseName
+	if len(paths) == 1 {
+		// Single path: keep the human-readable suffix, no hash needed.
+		safe := pathSafe(paths[0])
+		if safe == "" {
+			safe = "-root"
+		}
+		name = fmt.Sprintf("%s-%s", baseName, safe)
+	} else if len(paths) > 1 {
+		// Multiple paths: first path (readable) + hash of the full sorted set.
+		// e.g. ["/api", "/health"] → "{base}-api-3d2a1f8c"
+		// The hash disambiguates sets sharing the same first path; the readable
+		// prefix lets humans quickly identify the rule without inspecting the AP spec.
+		sorted := make([]string, len(paths))
+		copy(sorted, paths)
+		sort.Strings(sorted)
+		h := fnv.New32a()
+		for _, p := range sorted {
+			_, _ = h.Write([]byte(p))
+		}
+		first := pathSafe(sorted[0])
+		if first == "" {
+			first = "-root"
+		}
+		name = fmt.Sprintf("%s-%s-%08x", baseName, first, h.Sum32())
+	}
+	name = truncateName(name)
+	return name, namespace, crossNamespace
+}
+
+// truncateName ensures a Kubernetes resource name stays within the 253-char limit.
+// Names that fit are returned unchanged. Names that overflow are truncated to 244 chars
+// and suffixed with "-{fnv32hex(fullName)}" (9 chars) to keep them collision-resistant.
+func truncateName(name string) string {
+	const maxLen = 253
+	const hashSuffixLen = 9 // "-" + 8 hex chars
+	if len(name) <= maxLen {
+		return name
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	return fmt.Sprintf("%s-%08x", name[:maxLen-hashSuffixLen], h.Sum32())
+}
+
+// policyNameSuffix returns the AP name suffix for a given path set, mirroring policyName.
+func policyNameSuffix(paths []string) string {
+	if len(paths) == 1 {
+		safe := pathSafe(paths[0])
+		if safe == "" {
+			safe = "-root"
+		}
+		return "-" + safe
+	}
+	if len(paths) > 1 {
+		sorted := make([]string, len(paths))
+		copy(sorted, paths)
+		sort.Strings(sorted)
+		h := fnv.New32a()
+		for _, p := range sorted {
+			_, _ = h.Write([]byte(p))
+		}
+		first := pathSafe(sorted[0])
+		if first == "" {
+			first = "-root"
+		}
+		return fmt.Sprintf("-%s-%08x", first, h.Sum32())
+	}
+	return ""
+}
+
+// RequiredPermissions returns the RBAC permissions needed by this writer.
+func (w *IstioL7Writer) RequiredPermissions() []Permission {
+	return []Permission{
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "get"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "create"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "update"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "delete"},
+	}
+}
+
+// Apply creates or updates an AuthorizationPolicy for the given HTTPRoute+gateway+paths combination.
+// When paths is non-empty the AP name includes a path-safe suffix so each rule gets its own AP.
+func (w *IstioL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string) error {
+	apName, apNamespace, crossNamespace := policyName(route, gateway, paths)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: apName, Namespace: apNamespace},
+	}
+	rules := buildAuthorizationRules(ips, hosts, paths)
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		if !crossNamespace {
+			if err := ctrl.SetControllerReference(route, policy, scheme); err != nil {
+				return err
+			}
+		}
+		w.applyLabels(policy, route.Namespace, route.Name)
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules:  rules,
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// ListManaged returns all AuthorizationPolicies managed by this controller (identified by managedBy label).
+func (w *IstioL7Writer) ListManaged(ctx context.Context, managedBy string) ([]client.Object, error) {
+	list := &istiosecurityv1.AuthorizationPolicyList{}
+	if err := w.client.List(ctx, list, client.MatchingLabels{
+		"app.kubernetes.io/managed-by": managedBy,
+	}); err != nil {
+		return nil, err
+	}
+	result := make([]client.Object, len(list.Items))
+	for i, item := range list.Items {
+		result[i] = item
+	}
+	return result, nil
+}
+
+// IsOrphaned reports whether the given AP no longer has a valid owner HTTPRoute.
+func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool {
+	ownerNS := obj.GetLabels()[w.annotationPrefix+"/owner-namespace"]
+	ownerName := obj.GetLabels()[w.annotationPrefix+"/owner-name"]
+	mergeAnnotation := w.annotationPrefix + "/merge"
+
+	if ownerNS == "MERGED" {
+		// Merge-mode AP: check if any route still has this merge key
+		for i := range allRoutes {
+			if allRoutes[i].Annotations[mergeAnnotation] == ownerName {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Normal AP: check if owner route still exists and still produces this AP
+	for i := range allRoutes {
+		r := &allRoutes[i]
+		if r.Namespace != ownerNS || r.Name != ownerName {
+			continue
+		}
+		// Route exists — check if it's in merge mode now
+		if r.Annotations[mergeAnnotation] != "" {
+			return true
+		}
+		// Check if the route still produces this AP (exact or path-suffixed)
+		if w.routeProducesPolicy(r, obj.GetNamespace(), obj.GetName()) {
+			return false
+		}
+		return true
+	}
+
+	// Route not found in list — it's gone
+	return true
+}
+
+// Delete removes the given object from the cluster.
+func (w *IstioL7Writer) Delete(ctx context.Context, obj client.Object) error {
+	return client.IgnoreNotFound(w.client.Delete(ctx, obj))
+}
+
+// policyTarget is a single (namespace, name) pair identifying an AuthorizationPolicy.
+type policyTarget struct {
+	namespace string
+	name      string
+}
+
+// policyTargetsForRoute returns the exact set of AP (namespace, name) pairs that the
+// non-merge reconcile path would produce for route — mirrors the Apply call-sites exactly.
+// Used by IsOrphaned for exact matching — no prefix heuristics.
+func (w *IstioL7Writer) policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
+	granularity := route.Annotations[w.annotationPrefix+"/granularity"]
+
+	var targets []policyTarget
+	for _, ref := range gateway.GatewayParentRefs(route) {
+		refNS := route.Namespace
+		if ref.Namespace != nil {
+			refNS = string(*ref.Namespace)
+		}
+		crossNamespace := refNS != route.Namespace
+		targetNamespace := route.Namespace
+		gatewayName := string(ref.Name)
+		baseName := gatewayName + "-" + route.Name
+		if crossNamespace {
+			targetNamespace = refNS
+			baseName = gatewayName + "-" + route.Namespace + "-" + route.Name
+		}
+
+		// granularity=host: one AP with base name, no path suffix.
+		if granularity == "host" {
+			targets = append(targets, policyTarget{namespace: targetNamespace, name: baseName})
+			continue
+		}
+
+		// granularity=rule (default): one AP per rule with path suffix.
+		if len(route.Spec.Rules) == 0 {
+			targets = append(targets, policyTarget{namespace: targetNamespace, name: baseName})
+			continue
+		}
+		for _, rule := range route.Spec.Rules {
+			paths := w.TranslatePaths(rule.Matches)
+			targets = append(targets, policyTarget{
+				namespace: targetNamespace,
+				name:      truncateName(baseName + policyNameSuffix(paths)),
+			})
+		}
+	}
+	return targets
+}
+
+// routeProducesPolicy reports whether the non-merge reconcile path for route would generate
+// an AuthorizationPolicy at the given {namespace, name}. Uses exact matching only.
+func (w *IstioL7Writer) routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
+	for _, pt := range w.policyTargetsForRoute(route) {
+		if pt.namespace == policyNamespace && pt.name == policyName {
+			return true
+		}
+	}
+	return false
+}
+
+// buildAuthorizationRules builds the Istio rules for an AuthorizationPolicy.
+// When paths is non-empty, Operation.Paths is set to restrict to those paths.
+func buildAuthorizationRules(allowedIPs, hostnames, paths []string) []*istioApiSecurityV1.Rule {
+	rules := []*istioApiSecurityV1.Rule{
+		{
+			From: []*istioApiSecurityV1.Rule_From{
+				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: allowedIPs}},
+			},
+		},
+	}
+	if len(hostnames) > 0 || len(paths) > 0 {
+		op := &istioApiSecurityV1.Operation{}
+		if len(hostnames) > 0 {
+			op.Hosts = hostnames
+		}
+		if len(paths) > 0 {
+			op.Paths = paths
+		}
+		rules[0].To = []*istioApiSecurityV1.Rule_To{
+			{Operation: op},
+		}
+	}
+	return rules
+}
+
+// TranslatePaths implements PathTranslator for Istio AuthorizationPolicy path semantics.
+// PathPrefix /chaos → ["/chaos", "/chaos/*"] (exact + glob, covers /chaos and all sub-paths)
+// Exact /chaos     → ["/chaos"]              (passed through unchanged)
+// RegularExpression → skipped                (not supported by Istio AuthorizationPolicy)
+func (w *IstioL7Writer) TranslatePaths(matches []gatewayApiv1.HTTPRouteMatch) []string {
+	var paths []string
+	for _, match := range matches {
+		if match.Path == nil || match.Path.Value == nil {
+			continue
+		}
+		v := *match.Path.Value
+		t := gatewayApiv1.PathMatchPathPrefix // default per Gateway API spec
+		if match.Path.Type != nil {
+			t = *match.Path.Type
+		}
+		switch t {
+		case gatewayApiv1.PathMatchPathPrefix:
+			if v == "/" {
+				paths = append(paths, "/*")
+			} else {
+				paths = append(paths, v, v+"/*")
+			}
+		case gatewayApiv1.PathMatchExact:
+			paths = append(paths, v)
+		// RegularExpression: not supported by Istio AP — skip
+		}
+	}
+	return paths
+}
+
+// dedupSorted returns a sorted, deduplicated copy of the input slice.
+func dedupSorted(items []string) []string {
+	return sets.List(sets.New[string](items...))
+}

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"regexp"
-	"sort"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +31,7 @@ func LabelSafe(s string) string {
 	v := invalidLabelValue.ReplaceAllString(s, "_")
 	if len(v) > 63 {
 		h := fnv.New32a()
-		_, _ = h.Write([]byte(v))
+		_, _ = h.Write([]byte(s))
 		v = fmt.Sprintf("%s-%08x", v[:54], h.Sum32())
 	}
 	return v
@@ -67,22 +65,13 @@ func (w *IstioL7Writer) applyLabels(policy *istiosecurityv1.AuthorizationPolicy,
 	policy.Labels[w.annotationPrefix+"/owner-name"] = LabelSafe(ownerName)
 }
 
-// pathSafe converts a URL path to a safe AP name suffix.
-// Encoding: escape "-" as "--", trim surrounding "/", replace remaining "/" with "-".
-// Returns empty string only for "/" (or equivalent all-slash paths).
-// Examples: /admin/users → admin-users, /admin-users → admin--users, /root → root, / → ""
-func pathSafe(path string) string {
-	escaped := strings.ReplaceAll(path, "-", "--")
-	escaped = strings.Trim(escaped, "/")
-	return strings.ReplaceAll(escaped, "/", "-")
-}
-
 // policyName computes the AP name and namespace for a given route+gateway+paths.
 // Format: {gateway.Name}-{route.Name} (same-namespace)
 //
 //	{gateway.Name}-{route.Namespace}-{route.Name} (cross-namespace, AP lives in gateway's namespace)
 //
-// When paths is non-empty, a path-safe suffix is appended so each HTTPRoute rule gets its own AP.
+// When paths is non-empty, a FNV-32a hash of the sorted path set is appended so each HTTPRoute
+// rule gets its own AP. The hash is order-independent and collision-resistant.
 func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, paths []string) (name, namespace string, crossNamespace bool) {
 	crossNamespace = gateway.Namespace != route.Namespace
 	namespace = route.Namespace
@@ -92,30 +81,12 @@ func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, pa
 		baseName = gateway.Name + "-" + route.Namespace + "-" + route.Name
 	}
 	name = baseName
-	if len(paths) == 1 {
-		// Single path: keep the human-readable suffix, no hash needed.
-		safe := pathSafe(paths[0])
-		if safe == "" {
-			safe = "-root"
-		}
-		name = fmt.Sprintf("%s-%s", baseName, safe)
-	} else if len(paths) > 1 {
-		// Multiple paths: first path (readable) + hash of the full sorted set.
-		// e.g. ["/api", "/health"] → "{base}-api-3d2a1f8c"
-		// The hash disambiguates sets sharing the same first path; the readable
-		// prefix lets humans quickly identify the rule without inspecting the AP spec.
-		sorted := make([]string, len(paths))
-		copy(sorted, paths)
-		sort.Strings(sorted)
+	if len(paths) > 0 {
 		h := fnv.New32a()
-		for _, p := range sorted {
+		for _, p := range dedupSorted(paths) {
 			_, _ = h.Write([]byte(p))
 		}
-		first := pathSafe(sorted[0])
-		if first == "" {
-			first = "-root"
-		}
-		name = fmt.Sprintf("%s-%s-%08x", baseName, first, h.Sum32())
+		name = fmt.Sprintf("%s-%08x", baseName, h.Sum32())
 	}
 	name = truncateName(name)
 	return name, namespace, crossNamespace
@@ -137,28 +108,14 @@ func truncateName(name string) string {
 
 // policyNameSuffix returns the AP name suffix for a given path set, mirroring policyName.
 func policyNameSuffix(paths []string) string {
-	if len(paths) == 1 {
-		safe := pathSafe(paths[0])
-		if safe == "" {
-			safe = "-root"
-		}
-		return "-" + safe
+	if len(paths) == 0 {
+		return ""
 	}
-	if len(paths) > 1 {
-		sorted := make([]string, len(paths))
-		copy(sorted, paths)
-		sort.Strings(sorted)
-		h := fnv.New32a()
-		for _, p := range sorted {
-			_, _ = h.Write([]byte(p))
-		}
-		first := pathSafe(sorted[0])
-		if first == "" {
-			first = "-root"
-		}
-		return fmt.Sprintf("-%s-%08x", first, h.Sum32())
+	h := fnv.New32a()
+	for _, p := range dedupSorted(paths) {
+		_, _ = h.Write([]byte(p))
 	}
-	return ""
+	return fmt.Sprintf("-%08x", h.Sum32())
 }
 
 // RequiredPermissions returns the RBAC permissions needed by this writer.
@@ -172,9 +129,16 @@ func (w *IstioL7Writer) RequiredPermissions() []Permission {
 }
 
 // Apply creates or updates an AuthorizationPolicy for the given HTTPRoute+gateway+paths combination.
-// When paths is non-empty the AP name includes a path-safe suffix so each rule gets its own AP.
+// When paths is non-empty the AP name includes a hash suffix so each rule gets its own AP.
+// If ips is empty, any previously created AP for this route+paths is deleted instead.
 func (w *IstioL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string) error {
 	apName, apNamespace, crossNamespace := policyName(route, gateway, paths)
+	if len(ips) == 0 {
+		policy := &istiosecurityv1.AuthorizationPolicy{}
+		policy.Name = apName
+		policy.Namespace = apNamespace
+		return client.IgnoreNotFound(w.client.Delete(ctx, policy))
+	}
 
 	policy := &istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: apName, Namespace: apNamespace},
@@ -230,10 +194,11 @@ func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.H
 		return true
 	}
 
-	// Normal AP: check if owner route still exists and still produces this AP
+	// Normal AP: check if owner route still exists and still produces this AP.
+	// Labels are stored via LabelSafe() so we must compare using LabelSafe() on both sides.
 	for i := range allRoutes {
 		r := &allRoutes[i]
-		if r.Namespace != ownerNS || r.Name != ownerName {
+		if LabelSafe(r.Namespace) != ownerNS || LabelSafe(r.Name) != ownerName {
 			continue
 		}
 		// Route exists — check if it's in merge mode now

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -2,11 +2,11 @@ package writers
 
 import (
 	"context"
-	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	istioApiSecurityV1 "istio.io/api/security/v1"
@@ -51,16 +51,14 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 			continue
 		}
 
-		sortedIPs := make([]string, len(ips))
-		copy(sortedIPs, ips)
-		sort.Strings(sortedIPs)
+		sortedIPs := dedupSorted(ips)
 		cidrKey := strings.Join(sortedIPs, ",")
 
-		var hosts []string
+		var rawHosts []string
 		for _, h := range sibling.Spec.Hostnames {
-			hosts = append(hosts, string(h))
+			rawHosts = append(rawHosts, string(h))
 		}
-		sort.Strings(hosts)
+		hosts := dedupSorted(rawHosts)
 		hostKey := strings.Join(hosts, ",")
 
 		granularity := sibling.Annotations[granularityAnnotation]
@@ -83,8 +81,7 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 			continue
 		}
 		for _, rule := range sibling.Spec.Rules {
-			paths := w.TranslatePaths(rule.Matches)
-			sort.Strings(paths)
+			paths := dedupSorted(w.TranslatePaths(rule.Matches))
 			tuples = append(tuples, mergedTuple{
 				cidrKey: cidrKey, hostKey: hostKey,
 				cidrs: sortedIPs, hosts: hosts,
@@ -177,6 +174,14 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 	return err
 }
 
+// DeleteMerged removes the merged AuthorizationPolicy for the given merge key.
+func (w *IstioL7Writer) DeleteMerged(ctx context.Context, namespace, mergeKey string) error {
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	policy.Name = mergeKey
+	policy.Namespace = namespace
+	return client.IgnoreNotFound(w.client.Delete(ctx, policy))
+}
+
 // mergeTosByPaths compacts `to` operations sharing the same path set into one, merging their host lists.
 func mergeTosByPaths(tos []*istioApiSecurityV1.Rule_To) []*istioApiSecurityV1.Rule_To {
 	type group struct {
@@ -189,7 +194,7 @@ func mergeTosByPaths(tos []*istioApiSecurityV1.Rule_To) []*istioApiSecurityV1.Ru
 		if to.Operation == nil {
 			continue
 		}
-		pathKey := strings.Join(to.Operation.Paths, ",")
+		pathKey := strings.Join(dedupSorted(to.Operation.Paths), ",")
 		g, exists := byPathKey[pathKey]
 		if !exists {
 			g = &group{}

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -1,0 +1,215 @@
+package writers
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+// mergedTuple is a single (cidr-set, host-set, paths) entry emitted per rule during ApplyMerged grouping.
+type mergedTuple struct {
+	cidrKey string   // sorted joined CIDRs — group key
+	hostKey string   // sorted joined hosts — group key
+	cidrs   []string // original CIDRs (same order as cidrKey was built from)
+	hosts   []string // original hosts (same order as hostKey was built from)
+	paths   []string // paths for this rule (nil means host-only granularity)
+}
+
+// ApplyMerged creates or updates a merged AuthorizationPolicy for a merge group.
+//
+// Security model: routes with different CIDR sets must NOT share a `from` block,
+// otherwise a CIDR allowed on one host would implicitly gain access to another host.
+//
+// Algorithm (two-level grouping):
+//  1. For each sibling route, collect per-rule tuples: (sorted_cidrs, sorted_hosts, paths).
+//     When granularity=host the route contributes one tuple (no paths); otherwise one per rule.
+//  2. Group tuples by sorted_cidrs → one Istio Rule per unique CIDR set (one `from` block).
+//  3. Within each CIDR group, group by sorted_hosts → one `to` Operation per unique host set.
+//  4. Collect all paths from matching tuples into that Operation.
+//  5. Compact `to` operations sharing the same path set into one (merging their host lists).
+func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error {
+	granularityAnnotation := w.annotationPrefix + "/granularity"
+
+	var tuples []mergedTuple
+	for _, sibling := range siblings {
+		ips, err := w.cidrResolver.GetCidrsFromObject(ctx, sibling)
+		if err == w.cidrResolver.AnnotationNotFoundError() {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if len(ips) == 0 {
+			continue
+		}
+
+		sortedIPs := make([]string, len(ips))
+		copy(sortedIPs, ips)
+		sort.Strings(sortedIPs)
+		cidrKey := strings.Join(sortedIPs, ",")
+
+		var hosts []string
+		for _, h := range sibling.Spec.Hostnames {
+			hosts = append(hosts, string(h))
+		}
+		sort.Strings(hosts)
+		hostKey := strings.Join(hosts, ",")
+
+		granularity := sibling.Annotations[granularityAnnotation]
+		if granularity == "host" {
+			tuples = append(tuples, mergedTuple{
+				cidrKey: cidrKey, hostKey: hostKey,
+				cidrs: sortedIPs, hosts: hosts,
+				paths: nil,
+			})
+			continue
+		}
+
+		// granularity=rule (default): one tuple per HTTPRoute rule.
+		if len(sibling.Spec.Rules) == 0 {
+			tuples = append(tuples, mergedTuple{
+				cidrKey: cidrKey, hostKey: hostKey,
+				cidrs: sortedIPs, hosts: hosts,
+				paths: nil,
+			})
+			continue
+		}
+		for _, rule := range sibling.Spec.Rules {
+			paths := w.TranslatePaths(rule.Matches)
+			sort.Strings(paths)
+			tuples = append(tuples, mergedTuple{
+				cidrKey: cidrKey, hostKey: hostKey,
+				cidrs: sortedIPs, hosts: hosts,
+				paths: paths,
+			})
+		}
+	}
+
+	if len(tuples) == 0 {
+		return nil
+	}
+
+	// Group by cidrKey preserving first-seen order.
+	type hostPathGroup struct {
+		paths        []string
+		unrestricted bool // true if any route used granularity=host — overrides all path restrictions
+	}
+	type cidrGroup struct {
+		cidrs    []string
+		hostKeys []string
+		byHost   map[string]*hostPathGroup
+	}
+	cidrKeys := []string{}
+	byCIDR := map[string]*cidrGroup{}
+
+	for _, t := range tuples {
+		cg, exists := byCIDR[t.cidrKey]
+		if !exists {
+			cg = &cidrGroup{cidrs: t.cidrs, byHost: map[string]*hostPathGroup{}}
+			byCIDR[t.cidrKey] = cg
+			cidrKeys = append(cidrKeys, t.cidrKey)
+		}
+		hg, exists := cg.byHost[t.hostKey]
+		if !exists {
+			hg = &hostPathGroup{}
+			cg.byHost[t.hostKey] = hg
+			cg.hostKeys = append(cg.hostKeys, t.hostKey)
+		}
+		if t.paths == nil {
+			hg.unrestricted = true
+		} else {
+			hg.paths = append(hg.paths, t.paths...)
+		}
+	}
+
+	// Build Istio rules: one Rule per unique CIDR set.
+	var rules []*istioApiSecurityV1.Rule
+	for _, ck := range cidrKeys {
+		cg := byCIDR[ck]
+		rule := &istioApiSecurityV1.Rule{
+			From: []*istioApiSecurityV1.Rule_From{
+				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: cg.cidrs}},
+			},
+		}
+		for _, hk := range cg.hostKeys {
+			hg := cg.byHost[hk]
+			var hosts []string
+			if hk != "" {
+				hosts = strings.Split(hk, ",")
+			}
+			op := &istioApiSecurityV1.Operation{}
+			if len(hosts) > 0 {
+				op.Hosts = hosts
+			}
+			if !hg.unrestricted && len(hg.paths) > 0 {
+				op.Paths = dedupSorted(hg.paths)
+			}
+			if op.Hosts != nil || op.Paths != nil {
+				rule.To = append(rule.To, &istioApiSecurityV1.Rule_To{Operation: op})
+			}
+		}
+		rule.To = mergeTosByPaths(rule.To)
+		rules = append(rules, rule)
+	}
+
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: mergeKey, Namespace: gateway.Namespace},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		w.applyLabels(policy, "MERGED", mergeKey)
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules:  rules,
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// mergeTosByPaths compacts `to` operations sharing the same path set into one, merging their host lists.
+func mergeTosByPaths(tos []*istioApiSecurityV1.Rule_To) []*istioApiSecurityV1.Rule_To {
+	type group struct {
+		hosts []string
+	}
+	keys := []string{}
+	byPathKey := map[string]*group{}
+
+	for _, to := range tos {
+		if to.Operation == nil {
+			continue
+		}
+		pathKey := strings.Join(to.Operation.Paths, ",")
+		g, exists := byPathKey[pathKey]
+		if !exists {
+			g = &group{}
+			byPathKey[pathKey] = g
+			keys = append(keys, pathKey)
+		}
+		g.hosts = append(g.hosts, to.Operation.Hosts...)
+	}
+
+	merged := make([]*istioApiSecurityV1.Rule_To, 0, len(keys))
+	for _, pathKey := range keys {
+		g := byPathKey[pathKey]
+		op := &istioApiSecurityV1.Operation{}
+		if len(g.hosts) > 0 {
+			op.Hosts = dedupSorted(g.hosts)
+		}
+		if pathKey != "" {
+			op.Paths = strings.Split(pathKey, ",")
+		}
+		merged = append(merged, &istioApiSecurityV1.Rule_To{Operation: op})
+	}
+	return merged
+}

--- a/pkg/controllers/writers/istio_l7_merge_test.go
+++ b/pkg/controllers/writers/istio_l7_merge_test.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	istioApiSecurityV1 "istio.io/api/security/v1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 )
 
@@ -278,4 +279,24 @@ func TestApplyMerged_DeduplicatesPaths(t *testing.T) {
 	assert.Len(t, policy.Spec.Rules, 1)
 	assert.Len(t, policy.Spec.Rules[0].To, 1)
 	assert.ElementsMatch(t, []string{"/api", "/api/*"}, policy.Spec.Rules[0].To[0].Operation.Paths, "duplicate paths must appear only once after expansion")
+}
+
+// TestMergeTosByPaths_PathOrderIndependent verifies that two `to` operations with the same paths
+// in different order are compacted into one. Without sorting the path key, they would produce
+// different keys and survive as separate redundant `to` blocks — causing spurious AP updates.
+func TestMergeTosByPaths_PathOrderIndependent(t *testing.T) {
+	istioOp := func(hosts, paths []string) *istioApiSecurityV1.Rule_To {
+		return &istioApiSecurityV1.Rule_To{
+			Operation: &istioApiSecurityV1.Operation{Hosts: hosts, Paths: paths},
+		}
+	}
+
+	// Same paths, different order — must compact to one To block.
+	result := mergeTosByPaths([]*istioApiSecurityV1.Rule_To{
+		istioOp([]string{"host-a.example.com"}, []string{"/health", "/api"}),
+		istioOp([]string{"host-b.example.com"}, []string{"/api", "/health"}),
+	})
+	require.Len(t, result, 1, "same paths in different order must compact into one To operation")
+	assert.ElementsMatch(t, []string{"host-a.example.com", "host-b.example.com"}, result[0].Operation.Hosts)
+	assert.ElementsMatch(t, []string{"/api", "/health"}, result[0].Operation.Paths)
 }

--- a/pkg/controllers/writers/istio_l7_merge_test.go
+++ b/pkg/controllers/writers/istio_l7_merge_test.go
@@ -1,0 +1,281 @@
+package writers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+// allPolicyHosts collects every host across all rules and to-blocks of a policy.
+func allPolicyHosts(p *istiosecurityv1.AuthorizationPolicy) []string {
+	var hosts []string
+	for _, rule := range p.Spec.Rules {
+		for _, to := range rule.To {
+			if to.Operation != nil {
+				hosts = append(hosts, to.Operation.Hosts...)
+			}
+		}
+	}
+	return hosts
+}
+
+// allPolicyCIDRs collects every CIDR across all rules of a policy.
+func allPolicyCIDRs(p *istiosecurityv1.AuthorizationPolicy) []string {
+	var cidrs []string
+	for _, rule := range p.Spec.Rules {
+		for _, from := range rule.From {
+			if from.Source != nil {
+				cidrs = append(cidrs, from.Source.RemoteIpBlocks...)
+			}
+		}
+	}
+	return cidrs
+}
+
+// TestApplyMerged_SameCIDRSet verifies that two routes sharing the same CIDR set and no paths
+// are compacted into a single Rule with one `to` containing both hosts.
+func TestApplyMerged_SameCIDRSet(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	route0 := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route0.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route1 := testRoute("svc-b", "ns-b", "svc-b.example.com")
+	route1.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, route0, route1, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route0, route1}, "shared-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "shared-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 1, "same CIDR set must produce exactly one Rule")
+	assert.Equal(t, []string{"1.2.3.4/32"}, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+	assert.Len(t, policy.Spec.Rules[0].To, 1, "same path set must be compacted into one To operation")
+	assert.ElementsMatch(t, []string{"svc-a.example.com", "svc-b.example.com"}, allPolicyHosts(policy))
+}
+
+// TestApplyMerged_DifferentCIDRSets verifies that routes with different CIDR sets each
+// produce their own Rule — the security boundary between CIDR sets must not be crossed.
+func TestApplyMerged_DifferentCIDRSets(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "5.6.7.8/32")
+	route0 := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route0.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route1 := testRoute("svc-b", "ns-b", "svc-b.example.com")
+	route1.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, route0, route1, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route0, route1}, "multi-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "multi-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 2, "distinct CIDR sets must each produce their own Rule")
+	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, allPolicyCIDRs(policy))
+	assert.ElementsMatch(t, []string{"svc-a.example.com", "svc-b.example.com"}, allPolicyHosts(policy))
+
+	for _, rule := range policy.Spec.Rules {
+		cidr := rule.From[0].Source.RemoteIpBlocks[0]
+		host := rule.To[0].Operation.Hosts[0]
+		switch cidr {
+		case "1.2.3.4/32":
+			assert.Equal(t, "svc-a.example.com", host)
+		case "5.6.7.8/32":
+			assert.Equal(t, "svc-b.example.com", host)
+		default:
+			t.Fatalf("unexpected CIDR in rule: %s", cidr)
+		}
+	}
+}
+
+// TestApplyMerged_SameCIDRSameHost collapses paths from multiple rules into one `to`.
+func TestApplyMerged_SameCIDRSameHost(t *testing.T) {
+	cidr := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	pathValue1 := "/api"
+	pathValue2 := "/health"
+	route := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue1}}}},
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue2}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr, route, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 1)
+	assert.Len(t, policy.Spec.Rules[0].To, 1)
+	assert.ElementsMatch(t, []string{"/api", "/api/*", "/health", "/health/*"}, policy.Spec.Rules[0].To[0].Operation.Paths)
+}
+
+// TestApplyMerged_GranularityHost verifies that granularity=host produces no paths in the merged AP.
+func TestApplyMerged_GranularityHost(t *testing.T) {
+	cidr := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	pathValue := "/api"
+	route := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route.Annotations["ipam.adevinta.com/granularity"] = "host"
+	route.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr, route, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"svc-a.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Nil(t, policy.Spec.Rules[0].To[0].Operation.Paths, "granularity=host must produce no path restriction")
+}
+
+// TestApplyMerged_SamePathsDifferentHosts verifies that two routes with the same CIDR set and
+// the same path set but different hosts are compacted into a single `to` operation with both hosts.
+func TestApplyMerged_SamePathsDifferentHosts(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	pathValue := "/"
+	routeA := testRoute("svc-a", "ns-a", "host-a.example.com")
+	routeA.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeA.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	routeB := testRoute("svc-b", "ns-b", "host-b.example.com")
+	routeB.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeB.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, routeA, routeB, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{routeA, routeB}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	require.Len(t, policy.Spec.Rules, 1, "same CIDR set must produce one Rule")
+	require.Len(t, policy.Spec.Rules[0].To, 1, "same path set must be compacted into one To operation")
+	assert.ElementsMatch(t, []string{"host-a.example.com", "host-b.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Equal(t, []string{"/*"}, policy.Spec.Rules[0].To[0].Operation.Paths)
+}
+
+// TestApplyMerged_MixedGranularity verifies that when one route uses granularity=host and another
+// uses granularity=rule within the same host group, the merged AP must have no path restriction —
+// the host-granularity route wins and overrides any path restriction from the rule-granularity route.
+func TestApplyMerged_MixedGranularity(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	pathValue := "/api"
+	routeHost := testRoute("svc-host", "ns-a", "shared.example.com")
+	routeHost.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeHost.Annotations["ipam.adevinta.com/granularity"] = "host"
+	routeRule := testRoute("svc-rule", "ns-b", "shared.example.com")
+	routeRule.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeRule.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, routeHost, routeRule, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{routeHost, routeRule}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	require.Len(t, policy.Spec.Rules, 1)
+	require.Len(t, policy.Spec.Rules[0].To, 1)
+	assert.Equal(t, []string{"shared.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Nil(t, policy.Spec.Rules[0].To[0].Operation.Paths, "host-granularity route must suppress path restriction for the entire host group")
+}
+
+// TestApplyMerged_EmptySkipped verifies that routes without a CIDR annotation are skipped.
+func TestApplyMerged_EmptySkipped(t *testing.T) {
+	route := testRoute("no-cidr", "ns-a", "no-cidr.example.com")
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(route, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "no policy should be created when no CIDRs are available")
+}
+
+// TestApplyMerged_DeduplicatesPaths verifies that duplicate paths within the same host group are collapsed.
+func TestApplyMerged_DeduplicatesPaths(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	pathValue := "/api"
+	makeRoute := func(name, ns string) *gatewayApiv1.HTTPRoute {
+		r := testRoute(name, ns, "shared.example.com")
+		r.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+		r.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+			{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+		}
+		return r
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, makeRoute("svc-a", "ns-a"), makeRoute("svc-b", "ns-b"), gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{makeRoute("svc-a", "ns-a"), makeRoute("svc-b", "ns-b")}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 1)
+	assert.Len(t, policy.Spec.Rules[0].To, 1)
+	assert.ElementsMatch(t, []string{"/api", "/api/*"}, policy.Spec.Rules[0].To[0].Operation.Paths, "duplicate paths must appear only once after expansion")
+}

--- a/pkg/controllers/writers/istio_l7_test.go
+++ b/pkg/controllers/writers/istio_l7_test.go
@@ -220,10 +220,9 @@ func TestIsOrphaned_PathPrefixRoute(t *testing.T) {
 		"old single-path AP name must be orphaned after PathPrefix expansion fix")
 }
 
-// TestPolicyNameMultiPathNoCollision verifies the AP naming scheme for multi-path rules.
-// Single path: human-readable pathSafe suffix (unchanged from before).
-// Multiple paths: FNV-32a hex hash of the sorted set — valid K8s name chars, order-independent.
-func TestPolicyNameMultiPathNoCollision(t *testing.T) {
+// TestPolicyNameHashSuffix verifies the AP naming scheme: any non-empty path set produces
+// {base}-{fnv32hex}, order-independent and collision-resistant.
+func TestPolicyNameHashSuffix(t *testing.T) {
 	gw := &gatewayApiv1.Gateway{}
 	gw.Name = "gw"
 	gw.Namespace = "ns"
@@ -231,13 +230,13 @@ func TestPolicyNameMultiPathNoCollision(t *testing.T) {
 	route.Name = "r"
 	route.Namespace = "ns"
 
-	// Single path: readable suffix, no hash.
+	// Single path: hash suffix, no human-readable path in name.
 	nameSingle, _, _ := policyName(route, gw, []string{"/api"})
-	assert.Equal(t, "gw-r-api", nameSingle)
+	assert.Regexp(t, `^gw-r-[0-9a-f]{8}$`, nameSingle, "single path must produce {base}-{hash}")
 
-	// Multi-path: first path + hash suffix.
+	// Multiple paths: same format.
 	nameMulti, _, _ := policyName(route, gw, []string{"/api", "/health"})
-	assert.Regexp(t, `^gw-r-api-[0-9a-f]{8}$`, nameMulti, "multi-path name must be {base}-{firstPath}-{hash}")
+	assert.Regexp(t, `^gw-r-[0-9a-f]{8}$`, nameMulti, "multi-path must produce {base}-{hash}")
 
 	// Order must not matter.
 	nameReversed, _, _ := policyName(route, gw, []string{"/health", "/api"})
@@ -247,8 +246,12 @@ func TestPolicyNameMultiPathNoCollision(t *testing.T) {
 	nameOther, _, _ := policyName(route, gw, []string{"/api", "/admin"})
 	assert.NotEqual(t, nameMulti, nameOther, "different path sets must produce different names")
 
-	// Multi-path must never collide with single-path.
-	assert.NotEqual(t, nameMulti, nameSingle)
+	// Single-path and multi-path with same first path must differ.
+	assert.NotEqual(t, nameSingle, nameMulti)
+
+	// No paths: base name only.
+	nameBase, _, _ := policyName(route, gw, nil)
+	assert.Equal(t, "gw-r", nameBase)
 }
 
 // TestTruncateName verifies the 253-char name length cap.
@@ -312,4 +315,91 @@ func TestRoutePolicyPrefixOverlap(t *testing.T) {
 	}
 	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{routeApi}),
 		"AP gw-api must NOT be orphaned: route api still produces it")
+}
+
+// TestIsOrphaned_CrossNamespace verifies that orphan detection works correctly for
+// cross-namespace APs where the AP lives in the gateway's namespace but is owned by
+// a route in a different namespace.
+func TestIsOrphaned_CrossNamespace(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "route-ns"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gw", Namespace: &gwNS},
+			}},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	// Compute the expected cross-namespace AP name.
+	targets := w.policyTargetsForRoute(&route)
+	require.Len(t, targets, 1)
+	assert.Equal(t, "gw-ns", targets[0].namespace, "cross-namespace AP must live in gateway's namespace")
+
+	// Live cross-namespace AP — should NOT be orphaned.
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = targets[0].name
+	liveAP.Namespace = targets[0].namespace
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": LabelSafe("route-ns"),
+		"ipam.adevinta.com/owner-name":      LabelSafe("my-route"),
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{route}),
+		"cross-namespace AP at correct name must NOT be orphaned")
+
+	// Stale AP from a route that no longer exists — should be orphaned.
+	staleAP := &istiosecurityv1.AuthorizationPolicy{}
+	staleAP.Name = "my-gw-route-ns-deleted-route"
+	staleAP.Namespace = "gw-ns"
+	staleAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": LabelSafe("route-ns"),
+		"ipam.adevinta.com/owner-name":      LabelSafe("deleted-route"),
+	}
+	assert.True(t, w.IsOrphaned(staleAP, []gatewayApiv1.HTTPRoute{route}),
+		"AP for a deleted cross-namespace route must be orphaned")
+
+	// AP with wrong name for the existing route — should be orphaned (e.g. gateway changed).
+	wrongNameAP := &istiosecurityv1.AuthorizationPolicy{}
+	wrongNameAP.Name = "old-gw-route-ns-my-route"
+	wrongNameAP.Namespace = "gw-ns"
+	wrongNameAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": LabelSafe("route-ns"),
+		"ipam.adevinta.com/owner-name":      LabelSafe("my-route"),
+	}
+	assert.True(t, w.IsOrphaned(wrongNameAP, []gatewayApiv1.HTTPRoute{route}),
+		"AP with wrong name for existing cross-namespace route must be orphaned")
+}
+
+// TestIsOrphaned_LongRouteName verifies that routes with names > 63 chars (which get
+// truncated by LabelSafe) are still correctly recognised as owners during orphan detection.
+func TestIsOrphaned_LongRouteName(t *testing.T) {
+	longName := strings.Repeat("a", 54) + strings.Repeat("b", 20) // 74 chars — exceeds 63
+	gwNS := gatewayApiv1.Namespace("ns")
+	route := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: longName, Namespace: "ns"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	targets := w.policyTargetsForRoute(&route)
+	require.Len(t, targets, 1)
+
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = targets[0].name
+	liveAP.Namespace = targets[0].namespace
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": LabelSafe("ns"),
+		"ipam.adevinta.com/owner-name":      LabelSafe(longName),
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{route}),
+		"AP with LabelSafe'd long name must NOT be orphaned when route still exists")
 }

--- a/pkg/controllers/writers/istio_l7_test.go
+++ b/pkg/controllers/writers/istio_l7_test.go
@@ -1,0 +1,315 @@
+package writers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+var istioL7Scheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = gatewayApiv1.Install(s)
+	_ = istiosecurityv1.AddToScheme(s)
+	_ = ipamv1alpha1.AddToScheme(s)
+	return s
+}()
+
+func newIstioL7Writer(c client.Client) *IstioL7Writer {
+	resolver := resolvers.CidrResolver{Client: c, AnnotationPrefix: resolvers.DefaultPrefix}
+	return NewIstioL7Writer(c, "ingress-allowlisting-controller", resolver)
+}
+
+func testGateway(name, namespace string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+}
+
+func testRoute(name, namespace string, hostnames ...string) *gatewayApiv1.HTTPRoute {
+	r := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+	}
+	for _, h := range hostnames {
+		r.Spec.Hostnames = append(r.Spec.Hostnames, gatewayApiv1.Hostname(h))
+	}
+	return r
+}
+
+func testCIDRs(name, namespace string, cidrs ...string) *ipamv1alpha1.CIDRs {
+	return &ipamv1alpha1.CIDRs{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: cidrs},
+	}
+}
+
+// TestIstioPathsForRule verifies correct translation of HTTPRoute path match types.
+func TestIstioPathsForRule(t *testing.T) {
+	prefix := gatewayApiv1.PathMatchPathPrefix
+	exact := gatewayApiv1.PathMatchExact
+	regex := gatewayApiv1.PathMatchRegularExpression
+
+	api := "/api"
+	root := "/"
+	chaos := "/chaos"
+
+	tests := []struct {
+		name     string
+		matches  []gatewayApiv1.HTTPRouteMatch
+		expected []string
+	}{
+		{
+			name: "PathPrefix /api → /api and /api/*",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &api}},
+			},
+			expected: []string{"/api", "/api/*"},
+		},
+		{
+			name: "PathPrefix / → /* only (no double slash)",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &root}},
+			},
+			expected: []string{"/*"},
+		},
+		{
+			name: "Exact /chaos → /chaos only",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &exact, Value: &chaos}},
+			},
+			expected: []string{"/chaos"},
+		},
+		{
+			name: "RegularExpression → skipped",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &regex, Value: &api}},
+			},
+			expected: nil,
+		},
+		{
+			name: "nil type defaults to PathPrefix",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Value: &api}},
+			},
+			expected: []string{"/api", "/api/*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newIstioL7Writer(fake.NewClientBuilder().WithScheme(istioL7Scheme).Build())
+			assert.ElementsMatch(t, tc.expected, w.TranslatePaths(tc.matches))
+		})
+	}
+}
+
+// TestIsOrphaned_GranularityHost verifies that a route with granularity=host produces
+// the base AP name (no path suffix), and that orphan detection recognises it as live.
+func TestIsOrphaned_GranularityHost(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("ns")
+	prefix := gatewayApiv1.PathMatchPathPrefix
+	path := "/api"
+	route := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{"ipam.adevinta.com/granularity": "host"},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+			Rules: []gatewayApiv1.HTTPRouteRule{
+				{Matches: []gatewayApiv1.HTTPRouteMatch{
+					{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &path}},
+				}},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	// AP at base name (no path suffix) — what Apply actually creates for granularity=host.
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = "gw-my-route"
+	liveAP.Namespace = "ns"
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{route}),
+		"granularity=host AP at base name must NOT be orphaned")
+
+	// AP at path-suffixed name — what the old logic would have computed (bug).
+	staleAP := &istiosecurityv1.AuthorizationPolicy{}
+	staleAP.Name = "gw-my-route-api-" // some hash-suffixed name
+	staleAP.Namespace = "ns"
+	staleAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.True(t, w.IsOrphaned(staleAP, []gatewayApiv1.HTTPRoute{route}),
+		"path-suffixed AP must be orphaned when route uses granularity=host")
+}
+
+// TestIsOrphaned_PathPrefixRoute verifies that orphan detection correctly resolves the AP name
+// for a PathPrefix route (which expands to two paths and gets a hash-suffixed name).
+func TestIsOrphaned_PathPrefixRoute(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("ns")
+	prefix := gatewayApiv1.PathMatchPathPrefix
+	path := "/api"
+	route := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "ns"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+			Rules: []gatewayApiv1.HTTPRouteRule{
+				{Matches: []gatewayApiv1.HTTPRouteMatch{
+					{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &path}},
+				}},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	// Compute the name Apply would actually create.
+	targets := w.policyTargetsForRoute(&route)
+	require.Len(t, targets, 1)
+	liveAPName := targets[0].name
+
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = liveAPName
+	liveAP.Namespace = "ns"
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{route}),
+		"PathPrefix AP at correct hash name must NOT be orphaned")
+
+	// The old (pre-fix) name using only the raw path value.
+	oldAP := &istiosecurityv1.AuthorizationPolicy{}
+	oldAP.Name = "gw-my-route-api" // single-path name, no hash
+	oldAP.Namespace = "ns"
+	oldAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.True(t, w.IsOrphaned(oldAP, []gatewayApiv1.HTTPRoute{route}),
+		"old single-path AP name must be orphaned after PathPrefix expansion fix")
+}
+
+// TestPolicyNameMultiPathNoCollision verifies the AP naming scheme for multi-path rules.
+// Single path: human-readable pathSafe suffix (unchanged from before).
+// Multiple paths: FNV-32a hex hash of the sorted set — valid K8s name chars, order-independent.
+func TestPolicyNameMultiPathNoCollision(t *testing.T) {
+	gw := &gatewayApiv1.Gateway{}
+	gw.Name = "gw"
+	gw.Namespace = "ns"
+	route := &gatewayApiv1.HTTPRoute{}
+	route.Name = "r"
+	route.Namespace = "ns"
+
+	// Single path: readable suffix, no hash.
+	nameSingle, _, _ := policyName(route, gw, []string{"/api"})
+	assert.Equal(t, "gw-r-api", nameSingle)
+
+	// Multi-path: first path + hash suffix.
+	nameMulti, _, _ := policyName(route, gw, []string{"/api", "/health"})
+	assert.Regexp(t, `^gw-r-api-[0-9a-f]{8}$`, nameMulti, "multi-path name must be {base}-{firstPath}-{hash}")
+
+	// Order must not matter.
+	nameReversed, _, _ := policyName(route, gw, []string{"/health", "/api"})
+	assert.Equal(t, nameMulti, nameReversed, "path order must not affect the AP name")
+
+	// Different path sets must produce different names.
+	nameOther, _, _ := policyName(route, gw, []string{"/api", "/admin"})
+	assert.NotEqual(t, nameMulti, nameOther, "different path sets must produce different names")
+
+	// Multi-path must never collide with single-path.
+	assert.NotEqual(t, nameMulti, nameSingle)
+}
+
+// TestTruncateName verifies the 253-char name length cap.
+func TestTruncateName(t *testing.T) {
+	short := "my-gateway-my-route-api"
+	assert.Equal(t, short, truncateName(short))
+
+	exact := strings.Repeat("a", 253)
+	assert.Equal(t, exact, truncateName(exact))
+
+	long := strings.Repeat("a", 254)
+	result := truncateName(long)
+	assert.Len(t, result, 253)
+	assert.Regexp(t, `^a{244}-[0-9a-f]{8}$`, result)
+
+	longA := strings.Repeat("a", 244) + strings.Repeat("x", 10)
+	longB := strings.Repeat("a", 244) + strings.Repeat("y", 10)
+	assert.NotEqual(t, truncateName(longA), truncateName(longB))
+}
+
+// TestRoutePolicyPrefixOverlap is the regression test for the false-negative in IsOrphaned.
+//
+// Scenario: gateway "gw" in "ns". Two routes once existed: "api" and "api-v2".
+// "api"    → AP "gw-api"
+// "api-v2" → AP "gw-api-v2"
+//
+// "api-v2" is deleted. Cleanup must identify "gw-api-v2" as orphaned.
+// The old HasPrefix logic found route "api", computed base "gw-api", and concluded
+// HasPrefix("gw-api-v2", "gw-api-") == true → not orphaned (wrong).
+// The new exact-match logic finds no rule in route "api" that produces "gw-api-v2" → orphaned (correct).
+func TestRoutePolicyPrefixOverlap(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("ns")
+	routeApi := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	staleAP := &istiosecurityv1.AuthorizationPolicy{}
+	staleAP.Name = "gw-api-v2"
+	staleAP.Namespace = "ns"
+	staleAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "api",
+	}
+	assert.True(t, w.IsOrphaned(staleAP, []gatewayApiv1.HTTPRoute{routeApi}),
+		"AP gw-api-v2 must be orphaned: route api exists but only produces gw-api, not gw-api-v2")
+
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = "gw-api"
+	liveAP.Namespace = "ns"
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "api",
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{routeApi}),
+		"AP gw-api must NOT be orphaned: route api still produces it")
+}


### PR DESCRIPTION
Adds support for HTTPRoute resources alongside the existing Ingress and Gateway controllers. Enabled via `--httproute-support-enabled` flag or `httproute.enabled: true` in Helm.

* How it works

  The controller watches HTTPRoute objects and creates Istio AuthorizationPolicy resources. Gateway name and target namespace are derived automatically from spec.parentRefs - no extra annotations required beyond the existing `ipam.adevinta.com/allowlist-group / cluster-allowlist-group`.

* Naming:
  - Same-namespace parentRef → AP named <route-name> in route's namespace, with owner reference for automatic GC
  - Cross-namespace parentRef → AP named <route-namespace>-<route-name> in the gateway's namespace
  - Multiple Gateway parentRefs → one AP per gateway; first gets no index suffix, subsequent get -1, -2, ...

* Merge mode (`ipam.adevinta.com/merge=<key>`) - for staging environments where the same service is deployed across multiple namespaces pointing to a shared gateway. All `HTTPRoutes` sharing the same merge key and gateway produce a single AP with unioned CIDRs and hostnames. Not recommended for production - see security warning in README.

* Performance - annotation predicate filters reconcile events to only `HTTPRoutes` with allowlist annotations. Optional `--httproute-label-selector` restricts the informer cache at the API server level for clusters with
  thousands of `HTTPRoutes`.

* Labels - every managed AP carries `app.kubernetes.io/managed-by`, `ipam.adevinta.com/owner-namespace`, and `ipam.adevinta.com/owner-name` labels, enabling hard reset (via `kubectl delete authorizationpolicies -A -l
  app.kubernetes.io/managed-by=ingress-allowlisting-controller`).

* Orphan cleanup - on first reconcile after restart the controller sweeps all its APs and deletes any whose owner `HTTPRoute` no longer exists or would no longer produce that AP (covers: route deleted, parentRef removed, switch to/from merge mode). Cross-namespace APs **cannot use k8s GC** (owner refs are stripped cross-namespace), so restart-based cleanup is the designed solution.