### PR TITLE
feat(): redesign controller to use interfaces - modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ The controller generates in `my-app`:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: my-route          # httproute name
+  name: my-gateway-my-route     # {gateway.Name}-{httproute.Name}
   namespace: my-app
-  ownerReferences:        # automatically garbage-collected when the HTTPRoute is deleted
+  ownerReferences:               # automatically garbage-collected when the HTTPRoute is deleted
   - kind: HTTPRoute
     name: my-route
 spec:
@@ -198,7 +198,7 @@ The controller generates in `infra`:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: my-app-my-route   # <httproute-namespace>-<httproute-name>
+  name: cross-namespace-gateway-my-app-my-route   # {gateway.Name}-{httproute.Namespace}-{httproute.Name}
   namespace: infra
   # no ownerReference - cross-namespace owner references are not supported by Kubernetes
 spec:
@@ -230,14 +230,16 @@ spec:
 > kubectl rollout restart deployment/ingress-allowlisting-controller -n <namespace>
 > ```
 
-**Multiple gateways** - an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway. The first gets no index suffix; subsequent ones get `-1`, `-2`, etc.:
+**Multiple gateways** - an HTTPRoute can reference more than one gateway. The controller creates one `AuthorizationPolicy` per gateway, each prefixed with the gateway name:
 
 ```yaml
 spec:
   parentRefs:
-  - name: internal-gateway           # → AuthorizationPolicy: <httproute-namespace>-<httproute-name>
-  - name: external-gateway           # → AuthorizationPolicy: <httproute-namespace>-<httproute-name>-1
+  - name: internal-gateway           # → AuthorizationPolicy: internal-gateway-{httproute.Name}
+  - name: external-gateway           # → AuthorizationPolicy: external-gateway-{httproute.Name}
 ```
+
+Cross-namespace refs follow the same prefix convention: `{gateway.Name}-{httproute.Namespace}-{httproute.Name}`.
 
 **Performance tuning** - if you have thousands of HTTPRoutes in a cluster, you can restrict the informer cache to only the ones opted into allowlisting using a label selector:
 
@@ -293,13 +295,14 @@ spec:
   - chaos-monkey.public.ns-staging01.example.com
 ```
 
-The controller generates a **single** `AuthorizationPolicy` in `ns-infra`:
+The controller generates a **single** `AuthorizationPolicy` in `ns-infra`. Routes with the **same CIDR set** are compacted into one `rule`; routes with **different CIDR sets** each get their own `rule` — this preserves the security boundary (a CIDR allowed for one hostname cannot implicitly reach another):
 
 ```yaml
+# Example A: both routes share the same CIDR set (e.g. same allowlist object)
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: chaos-monkey      # = the merge key (first gateway, no suffix; second would be chaos-monkey-1)
+  name: chaos-monkey      # = the merge key
   namespace: ns-infra
 spec:
   action: ALLOW
@@ -307,12 +310,43 @@ spec:
   - from:
     - source:
         remoteIpBlocks:
-        - 1.2.3.4/32       # union of all sibling CIDRs
-        - 5.6.7.8/32
+        - 1.2.3.4/32       # shared CIDRs → one rule
     to:
     - operation:
         hosts:
         - chaos-monkey.public.ns-staging00.example.com
+    - operation:
+        hosts:
+        - chaos-monkey.public.ns-staging01.example.com
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: cross-namespace-public
+---
+# Example B: each route has a different CIDR set → one rule per CIDR set
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: chaos-monkey
+  namespace: ns-infra
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 1.2.3.4/32       # only ns-staging00's CIDRs
+    to:
+    - operation:
+        hosts:
+        - chaos-monkey.public.ns-staging00.example.com
+  - from:
+    - source:
+        remoteIpBlocks:
+        - 5.6.7.8/32       # only ns-staging01's CIDRs
+    to:
+    - operation:
+        hosts:
         - chaos-monkey.public.ns-staging01.example.com
   targetRefs:
   - group: gateway.networking.k8s.io
@@ -322,8 +356,38 @@ spec:
 
 Merge rules:
 - All HTTPRoutes with the **same annotation value** and the **same target gateway** are merged together, regardless of their `metadata.name`.
-- CIDRs and hostnames are deduplicated across all siblings.
+- Routes with the **same sorted CIDR set** share one `from` block (compacted for readability). Routes with different CIDR sets each get their own `rule` — security isolation is preserved.
+- Within a CIDR group, routes with the **same hostname set** share one `to` block, with all their paths collected together.
 - Reconciling any one sibling rebuilds the full merged policy.
+
+**Granularity** - by default the controller creates one `AuthorizationPolicy` per HTTPRoute rule (one per path set). Use the `ipam.adevinta.com/granularity` annotation to change this behaviour:
+
+| Value | AP count | AP name | `to` block |
+|---|---|---|---|
+| absent / `rule` | one per rule | `{gw}-{route}-{path}` | hosts + path from that rule |
+| `host` | one per route | `{gw}-{route}` | hosts only, no path restriction |
+
+```yaml
+# granularity=rule (default): separate AP per path
+metadata:
+  annotations:
+    ipam.adevinta.com/granularity: rule   # or omit entirely
+spec:
+  rules:
+  - matches:
+    - path:
+        value: /api      # → AP named {gw}-{route}-api
+  - matches:
+    - path:
+        value: /health   # → AP named {gw}-{route}-health
+---
+# granularity=host: one AP for the whole route, no path restriction
+metadata:
+  annotations:
+    ipam.adevinta.com/granularity: host
+```
+
+`granularity` also applies inside **merge mode**: when a sibling has `granularity=host`, its rule contributes to the merged AP without any path restriction; when it has `granularity=rule` (default), each rule's paths are included.
 
 > **Security warning:** Merge mode is **not recommended for production** environments. Any namespace in the cluster that sets the same merge key and points to the same gateway will be pulled into the same `AuthorizationPolicy`. This means a team controlling a different namespace could add their application's hostnames and CIDRs to your policy, potentially opening access to their service through your allowlist - or having their service inadvertently protected by your rules.
 >

--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,184 @@
+# Ingress Allowlisting Controller — Deep Dive
+
+## Architecture: Reconcilers vs Writers
+
+The controller has two conceptually different types of components:
+
+### Reconcilers (source-driven)
+Watch a Kubernetes object that **already exists** and inject CIDRs into it.
+The object is owned by someone else — the reconciler only mutates part of its spec.
+
+| Reconciler | Watches | Mutates | Target |
+|---|---|---|---|
+| `IngressReconciler` | `networking.k8s.io/v1 Ingress` | `nginx.ingress.kubernetes.io/whitelist-source-range` annotation | Nginx / cloud LB controllers |
+| `NetworkPolicyReconciler` | `networking.k8s.io/v1 NetworkPolicy` | `spec.ingress[].from[].ipBlock` | Any CNI enforcing standard NetworkPolicy |
+
+### Writers (creator-driven, Gateway API)
+Resolve a Gateway API object chain (`HTTPRoute → Gateway → GatewayClass → controllerName`) and **create a new enforcement object** specific to the ingress controller in use.
+Writers are registered in a registry keyed by `GatewayClass.spec.controllerName`.
+
+| Writer | Interface | Creates | Target Controller |
+|---|---|---|---|
+| `IstioL4Writer` | `L4PolicyWriter` | `security.istio.io/v1 AuthorizationPolicy` (TargetRef → Gateway) | Istio |
+| `IstioL7Writer` | `L7PolicyWriter` + `MergeableL7PolicyWriter` | `security.istio.io/v1 AuthorizationPolicy` (TargetRef → Gateway, per HTTPRoute) | Istio |
+
+### Resolution chain for writers
+
+```
+HTTPRoute
+  └─ spec.parentRefs[].name/namespace
+       └─ Gateway
+            └─ spec.gatewayClassName
+                 └─ GatewayClass
+                      └─ spec.controllerName  ──► L4WriterRegistry / L7WriterRegistry
+                                                        └─ Writer.Apply(...)
+                                                             └─ creates enforcement object
+```
+
+### Why interfaces?
+
+Writers are registered by controller name. Adding support for a new ingress controller (e.g. Envoy Gateway, Traefik) requires only:
+1. Implement `L4PolicyWriter` or `L7PolicyWriter`
+2. Add `RequiredPermissions()` so the RBAC preflight check covers it automatically
+3. Register in `controllers.go` — nothing else changes
+
+The reconciler (`HTTPRouteAllowlistingReconciler`, `GatewayAllowlistingReconciler`) is completely agnostic to the underlying enforcement technology.
+
+---
+
+## Controller Support Matrix
+
+### Gateway API — L4 (Gateway level)
+
+| Controller | `GatewayClass.controllerName` | Creates | Granularity | Implemented |
+|---|---|---|---|---|
+| Istio | `istio.io/gateway-controller` | `AuthorizationPolicy` (TargetRef → Gateway) | Gateway | ✅ |
+| Envoy Gateway | `gateway.envoyproxy.io/gatewayclass-controller` | `SecurityPolicy` (TargetRef → Gateway) | Gateway | 🔲 TODO |
+| Traefik | `traefik.io/gateway-controller` | — (no L4 Gateway-level policy) | — | 🔲 TODO |
+| Cilium | `io.cilium/gateway-controller` | — (pod-selector based, not Gateway API aware) | — | ➖ N/A |
+
+### Gateway API — L7 (HTTPRoute level)
+
+| Controller | `GatewayClass.controllerName` | Creates | Granularity | Merge support | Path support | Implemented |
+|---|---|---|---|---|---|---|
+| Istio | `istio.io/gateway-controller` | `AuthorizationPolicy` (TargetRef → Gateway, per route) | HTTPRoute + host + path | ✅ (`MergeableL7PolicyWriter`) | ✅ (`granularity` annotation) | ✅ |
+| Traefik | `traefik.io/gateway-controller` | `Middleware` (IPAllowList) | HTTPRoute | ➖ not supported | ➖ not applicable | 🔲 TODO |
+| Envoy Gateway | `gateway.envoyproxy.io/gatewayclass-controller` | `SecurityPolicy` (TargetRef → HTTPRoute) | HTTPRoute + host + path | 🔲 TODO | 🔲 TODO | 🔲 TODO |
+
+### Legacy / Non-Gateway API
+
+| Reconciler | Watches | Enforced by | L4/L7 | Granularity | Notes |
+|---|---|---|---|---|---|
+| `IngressReconciler` | `networking.k8s.io/v1 Ingress` | Nginx, cloud LBs | L7 | Ingress object | Patches annotation in place |
+| `NetworkPolicyReconciler` | `networking.k8s.io/v1 NetworkPolicy` | Any standard-compliant CNI | L3/L4 | Pod selector | See CNI support below |
+
+### CNI support via `networking.k8s.io/v1 NetworkPolicy`
+
+The `NetworkPolicyReconciler` writes standard `NetworkPolicy` objects with `ipBlock` rules.
+Any CNI that enforces the standard spec picks them up automatically:
+
+| CNI | Enforces `networking.k8s.io/v1 NetworkPolicy` | Notes |
+|---|---|---|
+| AWS VPC CNI | ✅ | Native, no extra config |
+| Calico | ✅ | Also has own `crd.projectcalico.org` CRDs with richer expression language |
+| Antrea | ✅ | Also has own `ClusterNetworkPolicy` with priority/tier system |
+| Cilium | ✅ (deprecated) | Prefers `CiliumNetworkPolicy`; standard spec supported but being phased out |
+| kube-router | ✅ | Standard spec only, no custom CRDs |
+| Flannel | ❌ | No network policy enforcement — objects are created but silently ignored |
+
+---
+
+## Pod-Oriented vs Gateway-Oriented
+
+A key architectural distinction:
+
+```
+Gateway API writers    → target Gateway/HTTPRoute objects (Istio, Traefik, Envoy Gateway)
+                         enforcement object knows about the Gateway topology
+
+Pod-oriented writers   → target pods via label selectors (Cilium CNP, Calico NP, Antrea NP)
+                         enforcement object has no concept of Gateway or HTTPRoute
+                         workload labels flow down: Deployment → ReplicaSet → Pod
+```
+
+Pod-oriented controllers are architecturally equivalent to the existing `NetworkPolicyReconciler` — a separate reconciler watching a pre-existing object, not a writer plugged into the Gateway API registry. If Cilium-native (`CiliumNetworkPolicy`) or Calico-native support is needed in the future, it should follow the same pattern as `NetworkPolicyReconciler`, not the writer interface.
+
+---
+
+## AuthorizationPolicy Naming
+
+### Convention
+
+All AP names follow a deterministic pattern derived from the objects involved. The gateway name is always the prefix — this prevents collisions when multiple gateways share the same namespace.
+
+| Scenario | Pattern | Example |
+|---|---|---|
+| Same-namespace, no paths | `{gw}-{route}` | `my-gateway-my-route` |
+| Same-namespace, single path | `{gw}-{route}-{pathSafe(path)}` | `my-gateway-my-route-api` |
+| Same-namespace, multiple paths | `{gw}-{route}-{pathSafe(paths[0])}-{fnv32hex}` | `my-gateway-my-route-api-3d2a1f8c` |
+| Cross-namespace, no paths | `{gw}-{routeNS}-{route}` | `my-gateway-app-ns-my-route` |
+| Cross-namespace, single path | `{gw}-{routeNS}-{route}-{pathSafe(path)}` | `my-gateway-app-ns-my-route-api` |
+| Cross-namespace, multiple paths | `{gw}-{routeNS}-{route}-{pathSafe(paths[0])}-{fnv32hex}` | `my-gateway-app-ns-my-route-api-3d2a1f8c` |
+| Merge mode | `{mergeKey}` | `chaos-monkey` |
+
+### `pathSafe` encoding
+
+`pathSafe` converts a URL path to a valid Kubernetes name segment:
+
+1. Escape `-` → `--` (so the separator `-` is never ambiguous)
+2. Trim leading and trailing `/`
+3. Replace remaining `/` with `-`
+
+Examples:
+
+| Path | `pathSafe` result |
+|---|---|
+| `/api` | `api` |
+| `/admin/users` | `admin-users` |
+| `/admin-users` | `admin--users` |
+| `/` | `""` → caller uses sentinel `-root` → final name ends `--root` |
+
+The double-dash prefix produced by `/` (`--root`) is unreachable by any real path, since `pathSafe` escapes all literal `-` first.
+
+### Multi-path collision protection
+
+When a rule has a single path the suffix is the plain readable `pathSafe` result. When a rule has **multiple paths** a hash is appended:
+
+```
+suffix = pathSafe(sorted_paths[0]) + "-" + hex8(fnv32a(sorted_paths))
+```
+
+- `sorted_paths[0]` gives a human-readable hint — operators can identify the rule at a glance
+- The FNV-32a hash covers the **full sorted set**, so two rules sharing the same first path but differing elsewhere get different names
+- Sorting makes the name order-independent — reordering matches in an HTTPRoute rule does not rename the AP
+- FNV-32a output is hex digits only (`[0-9a-f]`) — always a valid Kubernetes name segment
+
+Collision table:
+
+| Input | Suffix | Notes |
+|---|---|---|
+| `["/api"]` | `api` | single path, readable, no hash |
+| `["/api", "/health"]` | `api-3d2a1f8c` | multi-path, first + hash |
+| `["/api", "/admin"]` | `api-7b2e41f0` | same first path, different hash |
+| `["/api-v2"]` | `api--v2` | single path, dash escaped — never clashes with above |
+
+A same-namespace gateway named `my-gw` with route `r` would produce:
+```
+gw-r-api            ← single path /api
+gw-r-api-3d2a1f8c   ← paths [/api, /health]
+gw-r-api-7b2e41f0   ← paths [/api, /admin]
+gw-r-api--v2        ← single path /api-v2 (dash escaped)
+```
+
+None of these can ever collide.
+
+---
+
+## TODO
+
+| Priority | Item | Notes |
+|---|---|---|
+| 🟡 Medium | Envoy Gateway `SecurityPolicy` writer (L4 + L7) | Closest Istio equivalent; `targetRef` model is nearly identical |
+| 🟡 Medium | Traefik `Middleware` writer | IP allowlisting via `IPAllowList`; path filtering handled by HTTPRoute routing itself — no extra path restriction in the Middleware needed |
+| 🟠 Low | Cilium-native `CiliumNetworkPolicy` reconciler | Pod-selector based; separate reconciler pattern, not a writer |
+| 🟠 Low | Calico-native `NetworkPolicy` reconciler | Expression language differs from standard K8s; separate reconciler pattern |

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,12 +29,17 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -77,6 +84,10 @@ func main() {
 		restConfig.Impersonate.UserName = as
 	}
 
+	// nil client is fine here — writers are only used to call RequiredPermissions(), not for K8s ops.
+	l4Writers, l7Writers := controllers.BuildWriterRegistries(nil, "preflight", annotationPrefix)
+	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, l4Writers, l7Writers)
+
 	mgrOptions := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -111,5 +122,79 @@ func main() {
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Fatal(err, "problem running manager")
+	}
+}
+
+func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {
+	cs := kubernetes.NewForConfigOrDie(restConfig)
+
+	var perms []writers.Permission
+
+	// Always required — CIDRs and secret/configmap sources used by all controllers.
+	perms = append(perms,
+		writers.Permission{Group: "ipam.adevinta.com", Resource: "cidrs", Verb: "get"},
+		writers.Permission{Group: "ipam.adevinta.com", Resource: "clustercidrs", Verb: "get"},
+		writers.Permission{Group: "", Resource: "secrets", Verb: "get"},
+		writers.Permission{Group: "", Resource: "configmaps", Verb: "get"},
+	)
+
+	if gatewayEnabled {
+		perms = append(perms,
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gateways", Verb: "get"},
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses", Verb: "get"},
+		)
+		for _, w := range l4Writers {
+			if pp, ok := w.(writers.PermissionProvider); ok {
+				perms = append(perms, pp.RequiredPermissions()...)
+			}
+		}
+	}
+
+	if httpRouteEnabled {
+		perms = append(perms,
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "httproutes", Verb: "get"},
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gateways", Verb: "get"},
+			writers.Permission{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses", Verb: "get"},
+		)
+		for _, w := range l7Writers {
+			if pp, ok := w.(writers.PermissionProvider); ok {
+				perms = append(perms, pp.RequiredPermissions()...)
+			}
+		}
+	}
+
+	if networkPolicyEnabled {
+		perms = append(perms,
+			writers.Permission{Group: "networking.k8s.io", Resource: "networkpolicies", Verb: "get"},
+			writers.Permission{Group: "networking.k8s.io", Resource: "networkpolicies", Verb: "update"},
+		)
+	}
+
+	// Deduplicate before checking.
+	seen := map[writers.Permission]struct{}{}
+	for _, p := range perms {
+		if _, already := seen[p]; already {
+			continue
+		}
+		seen[p] = struct{}{}
+
+		sar := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Verb:     p.Verb,
+					Group:    p.Group,
+					Resource: p.Resource,
+				},
+			},
+		}
+		result, err := cs.AuthorizationV1().SelfSubjectAccessReviews().Create(
+			context.Background(), sar, metav1.CreateOptions{},
+		)
+		if err != nil {
+			setupLog.Fatal(fmt.Errorf("RBAC preflight: cannot check %s %s/%s: %w", p.Verb, p.Group, p.Resource, err), "preflight failed")
+		}
+		if !result.Status.Allowed {
+			setupLog.Fatal(fmt.Errorf("missing permission: cannot %s %s/%s — fix ClusterRole and redeploy", p.Verb, p.Group, p.Resource), "RBAC preflight failed")
+		}
 	}
 }

--- a/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
@@ -35,7 +35,7 @@ rules:
   verbs: ["get", "watch", "list"]
 {{- if .Values.gateway.enabled }}
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["gateways"]
+  resources: ["gateways", "gatewayclasses"]
   verbs: ["list","get", "watch"]
 - apiGroups: ["security.istio.io"]
   resources: ["authorizationpolicies"]
@@ -43,7 +43,7 @@ rules:
 {{- end }}
 {{- if .Values.httproute.enabled }}
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["httproutes"]
+  resources: ["httproutes", "gateways", "gatewayclasses"]
   verbs: ["list","get", "watch"]
 - apiGroups: ["security.istio.io"]
   resources: ["authorizationpolicies"]

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -10,6 +10,7 @@ import (
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -72,12 +73,25 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 		}
 	}
 
+	managedBy := "ingress-allowlisting-controller"
+	if namePrefix != "" {
+		managedBy = namePrefix + "-ingress-allowlisting-controller"
+	}
+
+	l4Writers := writers.L4WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL4Writer(mgr.GetClient()),
+	}
+	l7Writers := writers.L7WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL7Writer(mgr.GetClient(), managedBy, cidrResolver),
+	}
+
 	if gatewaySupportEnabled {
 		gatewayReconciler := GatewayAllowlistingReconciler{
 			Client:             mgr.GetClient(),
 			Scheme:             mgr.GetScheme(),
 			LegacyGroupVersion: legacyGroupVersion,
 			CidrResolver:       cidrResolver,
+			L4Writers:          l4Writers,
 		}
 		if err := gatewayReconciler.SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "Gateway"}
@@ -101,6 +115,7 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 			Scheme:             mgr.GetScheme(),
 			LegacyGroupVersion: legacyGroupVersion,
 			CidrResolver:       cidrResolver,
+			L7Writers:          l7Writers,
 		}
 		if err := httpRouteReconciler.SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "HTTPRoute"}

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
@@ -27,6 +28,19 @@ type setupError struct {
 
 func (e *setupError) Log(logger logr.Logger) {
 	logger.Error(e, "unable to create controller", "controller", "Ingress")
+}
+
+// BuildWriterRegistries constructs the L4 and L7 writer registries based on which controllers
+// are enabled. Called from main.go before the manager starts so permissions can be checked.
+func BuildWriterRegistries(c client.Client, managedBy, annotationPrefix string) (writers.L4WriterRegistry, writers.L7WriterRegistry) {
+	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: c}
+	l4 := writers.L4WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL4Writer(c),
+	}
+	l7 := writers.L7WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL7Writer(c, managedBy, cidrResolver),
+	}
+	return l4, l7
 }
 
 func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string) error {
@@ -83,6 +97,7 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 	}
 	l7Writers := writers.L7WriterRegistry{
 		writers.IstioControllerName: writers.NewIstioL7Writer(mgr.GetClient(), managedBy, cidrResolver),
+		//		writers.TraefikControllerName: writers.NewTraefikL7Writer(mgr.GetClient(), managedBy, cidrResolver),
 	}
 
 	if gatewaySupportEnabled {
@@ -166,6 +181,9 @@ func Scheme(legacyGroupVersion string) (*runtime.Scheme, error) {
 	if err := istiosecurityv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
+	//	if err := writers.AddTraefikToScheme(scheme); err != nil {
+	//		return nil, err
+	//	}
 
 	if legacyGroupVersion != "" {
 		var err error

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -352,6 +352,10 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "group-name", Namespace: currentNamespaceName},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
 	}
+	gwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "istio"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: "istio.io/gateway-controller"},
+	}
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test",
@@ -360,8 +364,9 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 				"ipam.example.com/allowlist-group": "group-name",
 			},
 		},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gwClass, gateway).Build()
 
 	k8sCache := &testCache{Client: k8sClient, scheme: extendedScheme}
 
@@ -442,6 +447,10 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "group-name"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
 	}
+	gwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "istio"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: "istio.io/gateway-controller"},
+	}
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test",
@@ -450,8 +459,9 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 				"ipam.example.com/cluster-allowlist-group": "group-name",
 			},
 		},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrs, gwClass, gateway).Build()
 
 	k8sCache := &testCache{Client: k8sClient, scheme: extendedScheme}
 

--- a/pkg/controllers/gateway_controller.go
+++ b/pkg/controllers/gateway_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -12,14 +11,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	istioApiSecurityV1 "istio.io/api/security/v1"
-	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
 
@@ -29,6 +27,7 @@ type GatewayAllowlistingReconciler struct {
 	LegacyGroupVersion string
 	Prefix             string
 	CidrResolver       resolvers.CidrResolver
+	L4Writers          writers.L4WriterRegistry
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
@@ -41,7 +40,7 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 	if err := r.Get(ctx, req.NamespacedName, &gateway); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Infof("Gateway %s being reconciled. Creating/updating allowlist...", gateway.GetName())
+	log.Infof("Gateway %s being reconciled. Creating/updating writers...", gateway.GetName())
 	var allowedIps []string
 	var err error
 	allowedIps, err = r.CidrResolver.GetCidrsFromObject(ctx, &gateway)
@@ -52,39 +51,26 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	generatedAuthorizationPolicy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gateway.Name,
-			Namespace: gateway.Namespace,
-		},
+	// Resolve GatewayClass to find which writer to use
+	gwClass := &gatewayApiv1.GatewayClass{}
+	if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, err
+		}
+		log.Infof("GatewayClass %s not found, skipping gateway %s", gateway.Spec.GatewayClassName, gateway.Name)
+		return ctrl.Result{}, nil
 	}
 
-	_, err = ctrl.CreateOrUpdate(ctx, r.Client, generatedAuthorizationPolicy, func() error {
-		generatedAuthorizationPolicy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW, // ALLOW is the default action; somehow, the action field is empty when examining the resource after creation
-			Rules: []*istioApiSecurityV1.Rule{
-				{
-					From: []*istioApiSecurityV1.Rule_From{
-						{
-							Source: &istioApiSecurityV1.Source{
-								RemoteIpBlocks: allowedIps,
-							},
-						},
-					},
-				},
-			},
-			TargetRef: &istioApiTypeV1beta1.PolicyTargetReference{
-				Name:  gateway.Name,
-				Kind:  "Gateway",
-				Group: "gateway.networking.k8s.io",
-			},
-		}
-		return nil
-	})
-	if err != nil {
+	writer, ok := r.L4Writers[string(gwClass.Spec.ControllerName)]
+	if !ok {
+		log.Infof("no L4 writer registered for controller %s, skipping gateway %s", gwClass.Spec.ControllerName, gateway.Name)
+		return ctrl.Result{}, nil
+	}
+
+	if err := writer.Apply(ctx, &gateway, allowedIps); err != nil {
 		return ctrl.Result{}, err
 	}
-	log.Infof("AuthorizationPolicy %s created/updated for gateway %s", generatedAuthorizationPolicy.Name, gateway.GetName())
+	log.Infof("AuthorizationPolicy created/updated for gateway %s", gateway.GetName())
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controllers/gateway_controller.go
+++ b/pkg/controllers/gateway_controller.go
@@ -32,6 +32,7 @@ type GatewayAllowlistingReconciler struct {
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
 
 func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -67,7 +68,7 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	if err := writer.Apply(ctx, &gateway, allowedIps); err != nil {
+	if err := writer.Apply(ctx, r.Scheme, &gateway, allowedIps); err != nil {
 		return ctrl.Result{}, err
 	}
 	log.Infof("AuthorizationPolicy created/updated for gateway %s", gateway.GetName())

--- a/pkg/controllers/gateway_controller_test.go
+++ b/pkg/controllers/gateway_controller_test.go
@@ -10,6 +10,7 @@ import (
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -32,10 +33,23 @@ func init() {
 	}
 }
 
+// newGatewayClass creates an Istio GatewayClass with the given name.
+func newGatewayClass(name string) *gatewayApiv1.GatewayClass {
+	return &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: name},
+		Spec: gatewayApiv1.GatewayClassSpec{
+			ControllerName: gatewayApiv1.GatewayController(writers.IstioControllerName),
+		},
+	}
+}
+
 func newGatewayReconciler(t *testing.T, k8sClient client.Client, scheme *runtime.Scheme) *GatewayAllowlistingReconciler {
 	t.Helper()
 	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
-	return &GatewayAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme}
+	l4Writers := writers.L4WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL4Writer(k8sClient),
+	}
+	return &GatewayAllowlistingReconciler{Client: k8sClient, CidrResolver: resolver, Scheme: scheme, L4Writers: l4Writers}
 }
 
 // cases:
@@ -65,13 +79,15 @@ func TestReconcileGateway(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32", "8.8.8.8/32"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/cluster-allowlist-group": "globalnet",
 			"ipam.adevinta.com/allowlist-group":         "localnet,dnssource",
 		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, globalCidrs).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, globalCidrs, gwClass).Build()
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
@@ -123,12 +139,14 @@ func TestReconcileGatewayWithClusterCIDR(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "anotherglobalnet"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"15.13.12.0/24"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
 			"ipam.adevinta.com/cluster-allowlist-group": "globalnet,anotherglobalnet",
 		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, globalNet, anotherGlobalNet).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, globalNet, anotherGlobalNet, gwClass).Build()
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: v1.ObjectMeta{
@@ -179,6 +197,7 @@ func TestReconcileGatewayNoAnnotations(t *testing.T) {
 	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
+	// Note: no GatewayClass needed here because the reconciler returns early on AnnotationNotFoundError
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
@@ -197,10 +216,12 @@ func TestReconcileGatewayPartialNotFound(t *testing.T) {
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}},
 	}
 
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet,notexisting"}},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, gateway, gwClass).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
@@ -250,10 +271,12 @@ func TestReconcileGatewayWithInvalidCIDRIpsNoError(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32", "8.8.8.8/32"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet,dnssource"}},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, gwClass).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{
@@ -300,10 +323,12 @@ func TestReconcileGatewayWithInvalidCIDRIpsNoError(t *testing.T) {
 
 func TestReconcileGatewayCIDRsNotFound(t *testing.T) {
 	t.Run("Namespace CIDR not found", func(t *testing.T) {
+		gwClass := newGatewayClass("istio")
 		gateway := &gatewayApiv1.Gateway{
 			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "notexisting,alsonotexisting"}},
+			Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway).Build()
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, gwClass).Build()
 		reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 		expectedPolicy := istiosecurityv1.AuthorizationPolicy{
 			ObjectMeta: v1.ObjectMeta{
@@ -362,10 +387,12 @@ func TestReconcileGatewayCIDRsNotFound(t *testing.T) {
 	})
 
 	t.Run("Cluster CIDR not found", func(t *testing.T) {
+		gwClass := newGatewayClass("istio")
 		gateway := &gatewayApiv1.Gateway{
 			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/cluster-allowlist-group": "notexisting,alsonotexisting"}},
+			Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway).Build()
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, gwClass).Build()
 		reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 		expectedPolicy := istiosecurityv1.AuthorizationPolicy{
 			ObjectMeta: v1.ObjectMeta{
@@ -444,10 +471,12 @@ func TestReconcileGatewayInvalidAnnotationFormat(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "dnssource", Namespace: "mynamespace"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.1.1.1/32", "8.8.8.8/32"}},
 	}
+	gwClass := newGatewayClass("istio")
 	gateway := &gatewayApiv1.Gateway{
 		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet, dnssource"}},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, gateway, gwClass).Build()
 
 	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
 	expectedPolicy := istiosecurityv1.AuthorizationPolicy{

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,6 +40,8 @@ type HTTPRouteAllowlistingReconciler struct {
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
 
 // gatewayParentRefs returns all parentRefs that target a Gateway.
@@ -57,6 +61,10 @@ func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentR
 
 func (r *HTTPRouteAllowlistingReconciler) mergeAnnotation() string {
 	return r.CidrResolver.AnnotationPrefix + "/merge"
+}
+
+func (r *HTTPRouteAllowlistingReconciler) granularityAnnotation() string {
+	return r.CidrResolver.AnnotationPrefix + "/granularity"
 }
 
 func (r *HTTPRouteAllowlistingReconciler) managedByValue() string {
@@ -82,12 +90,15 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	if mergeKey := httproute.Annotations[r.mergeAnnotation()]; mergeKey != "" {
-		i := 0
+		if err := validateMergeKey(mergeKey); err != nil {
+			log.Errorf("HTTPRoute %s/%s has invalid merge key: %v", httproute.Namespace, httproute.GetName(), err)
+			return ctrl.Result{}, err
+		}
 		for _, ref := range parentRefs {
-			if ref.Namespace == nil || string(*ref.Namespace) == httproute.Namespace {
-				continue // merge only applies to cross-namespace refs
+			gatewayNS := httproute.Namespace // nil Namespace means same namespace as the route
+			if ref.Namespace != nil {
+				gatewayNS = string(*ref.Namespace)
 			}
-			gatewayNS := string(*ref.Namespace)
 			gateway := &gatewayApiv1.Gateway{}
 			if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
 				if client.IgnoreNotFound(err) != nil {
@@ -114,10 +125,9 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 				log.Infof("writer for controller %s does not support merge, skipping", gwClass.Spec.ControllerName)
 				continue
 			}
-			if err := r.reconcileMergedGateway(ctx, &httproute, gateway, mw, mergeKey, i); err != nil {
+			if err := r.reconcileMergedGateway(ctx, &httproute, gateway, mw, mergeKey); err != nil {
 				return ctrl.Result{}, err
 			}
-			i++
 		}
 		return ctrl.Result{}, nil
 	}
@@ -135,7 +145,23 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		hostnames = append(hostnames, string(h))
 	}
 
-	for i, ref := range parentRefs {
+	granularity := httproute.Annotations[r.granularityAnnotation()]
+
+	// Collect per-rule paths: one entry per rule, nil if the rule has no path matches.
+	// Only needed for granularity=rule (default).
+	var rulePaths [][]string
+	if granularity == "" || granularity == "rule" {
+		rulePaths = make([][]string, len(httproute.Spec.Rules))
+		for i, rule := range httproute.Spec.Rules {
+			for _, match := range rule.Matches {
+				if match.Path != nil && match.Path.Value != nil {
+					rulePaths[i] = append(rulePaths[i], *match.Path.Value)
+				}
+			}
+		}
+	}
+
+	for _, ref := range parentRefs {
 		gatewayNS := httproute.Namespace
 		if ref.Namespace != nil {
 			gatewayNS = string(*ref.Namespace)
@@ -161,10 +187,30 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
 			continue
 		}
-		if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil, i); err != nil {
-			return ctrl.Result{}, err
+
+		switch granularity {
+		case "host":
+			// One AP per route, host-matched, no path restriction.
+			if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.Infof("policy (host) created/updated for HTTPRoute %s → gateway %s/%s", httproute.GetName(), gateway.Namespace, gateway.Name)
+		default:
+			// granularity=rule (default): one AP per HTTPRoute rule.
+			for ruleIdx, paths := range rulePaths {
+				if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, paths); err != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("policy (rule) created/updated for HTTPRoute %s rule %d → gateway %s/%s", httproute.GetName(), ruleIdx, gateway.Namespace, gateway.Name)
+			}
+			// Fallback: HTTPRoute with no rules — single AP, no path restriction.
+			if len(rulePaths) == 0 {
+				if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil); err != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("policy (rule/fallback) created/updated for HTTPRoute %s → gateway %s/%s", httproute.GetName(), gateway.Namespace, gateway.Name)
+			}
 		}
-		log.Infof("AuthorizationPolicy created/updated for HTTPRoute %s parentRef %d", httproute.GetName(), i)
 	}
 
 	return ctrl.Result{}, nil
@@ -217,7 +263,7 @@ func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context)
 	}
 }
 
-func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, writer writers.MergeableL7PolicyWriter, mergeKey string, i int) error {
+func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, writer writers.MergeableL7PolicyWriter, mergeKey string) error {
 	log := log.DefaultLogger.WithContext(ctx)
 
 	allRoutes := &gatewayApiv1.HTTPRouteList{}
@@ -237,7 +283,7 @@ func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Con
 		siblings = append(siblings, sibling)
 	}
 
-	if err := writer.ApplyMerged(ctx, gateway, siblings, mergeKey, i); err != nil {
+	if err := writer.ApplyMerged(ctx, gateway, siblings, mergeKey); err != nil {
 		return err
 	}
 	log.Infof("Merged AuthorizationPolicy created/updated for merge group %q → gateway %s/%s", mergeKey, gateway.Namespace, gateway.Name)
@@ -274,11 +320,31 @@ func (r *HTTPRouteAllowlistingReconciler) mergeSiblingEnqueuer() handler.EventHa
 
 func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, gatewayNamespace string) bool {
 	for _, ref := range gatewayParentRefs(httproute) {
-		if string(ref.Name) == gatewayName && ref.Namespace != nil && string(*ref.Namespace) == gatewayNamespace {
+		if string(ref.Name) != gatewayName {
+			continue
+		}
+		// nil Namespace means same namespace as the route — resolve it before comparing.
+		refNS := httproute.Namespace
+		if ref.Namespace != nil {
+			refNS = string(*ref.Namespace)
+		}
+		if refNS == gatewayNamespace {
 			return true
 		}
 	}
 	return false
+}
+
+// validK8sName matches a valid Kubernetes resource name: lowercase alphanumeric and hyphens,
+// must start and end with alphanumeric, max 253 chars.
+var validK8sName = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-\.]{0,251}[a-z0-9])?$`)
+
+// validateMergeKey returns an error if key is not a valid Kubernetes resource name.
+func validateMergeKey(key string) error {
+	if !validK8sName.MatchString(key) {
+		return fmt.Errorf("merge key %q is not a valid Kubernetes resource name: must match [a-z0-9][a-z0-9-.]*[a-z0-9] and be ≤253 chars", key)
+	}
+	return nil
 }
 
 func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {
@@ -337,7 +403,7 @@ func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nam
 		build = build.Named(namePrefix + "-httproute")
 	}
 	if r.LegacyGroupVersion != "" {
-		build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
+		build = build.Watches(&ipamv1alpha1_legacy.ClusterCIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.ClusterAnnotation()))).
 			Watches(&ipamv1alpha1_legacy.CIDRs{}, handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation())))
 	}
 	return build.Complete(r)
@@ -349,7 +415,7 @@ func newHTTPRoutesFromCIDRFuncMap(c client.Client, annotation string) handler.Ma
 		options := client.ListOptions{
 			Namespace: cidr.GetNamespace(),
 		}
-		err := c.List(context.Background(), httproutes, &options)
+		err := c.List(ctx, httproutes, &options)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/adevinta/go-log-toolkit"
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
@@ -43,21 +44,6 @@ type HTTPRouteAllowlistingReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
-
-// gatewayParentRefs returns all parentRefs that target a Gateway.
-func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
-	var refs []gatewayApiv1.ParentReference
-	for _, ref := range httproute.Spec.ParentRefs {
-		if ref.Kind != nil && *ref.Kind != "Gateway" {
-			continue
-		}
-		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
-			continue
-		}
-		refs = append(refs, ref)
-	}
-	return refs
-}
 
 func (r *HTTPRouteAllowlistingReconciler) mergeAnnotation() string {
 	return r.CidrResolver.AnnotationPrefix + "/merge"
@@ -83,7 +69,7 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	}
 	log.Infof("HTTPRoute %s being reconciled. Creating/updating writers...", httproute.GetName())
 
-	parentRefs := gatewayParentRefs(&httproute)
+	parentRefs := gateway.GatewayParentRefs(&httproute)
 	if len(parentRefs) == 0 {
 		log.Infof("HTTPRoute %s has no Gateway parentRefs, skipping", httproute.GetName())
 		return ctrl.Result{}, nil
@@ -147,20 +133,6 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 
 	granularity := httproute.Annotations[r.granularityAnnotation()]
 
-	// Collect per-rule paths: one entry per rule, nil if the rule has no path matches.
-	// Only needed for granularity=rule (default).
-	var rulePaths [][]string
-	if granularity == "" || granularity == "rule" {
-		rulePaths = make([][]string, len(httproute.Spec.Rules))
-		for i, rule := range httproute.Spec.Rules {
-			for _, match := range rule.Matches {
-				if match.Path != nil && match.Path.Value != nil {
-					rulePaths[i] = append(rulePaths[i], *match.Path.Value)
-				}
-			}
-		}
-	}
-
 	for _, ref := range parentRefs {
 		gatewayNS := httproute.Namespace
 		if ref.Namespace != nil {
@@ -186,6 +158,15 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		if !ok {
 			log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
 			continue
+		}
+
+		// Collect per-rule paths using the writer's translation (if it implements PathTranslator).
+		var rulePaths [][]string
+		if granularity == "" || granularity == "rule" {
+			rulePaths = make([][]string, len(httproute.Spec.Rules))
+			for i, rule := range httproute.Spec.Rules {
+				rulePaths[i] = translatePaths(writer, rule.Matches)
+			}
 		}
 
 		switch granularity {
@@ -319,7 +300,7 @@ func (r *HTTPRouteAllowlistingReconciler) mergeSiblingEnqueuer() handler.EventHa
 }
 
 func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, gatewayNamespace string) bool {
-	for _, ref := range gatewayParentRefs(httproute) {
+	for _, ref := range gateway.GatewayParentRefs(httproute) {
 		if string(ref.Name) != gatewayName {
 			continue
 		}
@@ -345,6 +326,21 @@ func validateMergeKey(key string) error {
 		return fmt.Errorf("merge key %q is not a valid Kubernetes resource name: must match [a-z0-9][a-z0-9-.]*[a-z0-9] and be ≤253 chars", key)
 	}
 	return nil
+}
+
+// translatePaths delegates path translation to the writer if it implements PathTranslator,
+// falling back to raw path values for writers that handle their own path semantics.
+func translatePaths(writer writers.L7PolicyWriter, matches []gatewayApiv1.HTTPRouteMatch) []string {
+	if pt, ok := writer.(writers.PathTranslator); ok {
+		return pt.TranslatePaths(matches)
+	}
+	var paths []string
+	for _, match := range matches {
+		if match.Path != nil && match.Path.Value != nil {
+			paths = append(paths, *match.Path.Value)
+		}
+	}
+	return paths
 }
 
 func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -2,10 +2,8 @@ package controllers
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 	"strings"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,14 +16,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	workqueue "k8s.io/client-go/util/workqueue"
 
-	istioApiSecurityV1 "istio.io/api/security/v1"
-	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/adevinta/go-log-toolkit"
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
 
@@ -36,47 +33,12 @@ type HTTPRouteAllowlistingReconciler struct {
 	LegacyGroupVersion string
 	Prefix             string
 	CidrResolver       resolvers.CidrResolver
+	L7Writers          writers.L7WriterRegistry
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
-
-type policyTarget struct {
-	namespace      string
-	name           string
-	gatewayName    string
-	crossNamespace bool
-	ref            gatewayApiv1.ParentReference
-}
-
-// policyTargets computes the complete set of AuthorizationPolicies that the non-merge
-// reconcile path would produce for route: one per Gateway parentRef, with namespace and
-// name derived from the cross-namespace flag and index. Single source of truth for AP naming.
-func policyTargets(route *gatewayApiv1.HTTPRoute) []policyTarget {
-	var targets []policyTarget
-	for i, ref := range gatewayParentRefs(route) {
-		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != route.Namespace
-		targetNamespace := route.Namespace
-		baseName := route.Name
-		if crossNamespace {
-			targetNamespace = string(*ref.Namespace)
-			baseName = route.Namespace + "-" + route.Name
-		}
-		name := baseName
-		if i > 0 {
-			name = fmt.Sprintf("%s-%d", baseName, i)
-		}
-		targets = append(targets, policyTarget{
-			namespace:      targetNamespace,
-			name:           name,
-			gatewayName:    string(ref.Name),
-			crossNamespace: crossNamespace,
-			ref:            ref,
-		})
-	}
-	return targets
-}
 
 // gatewayParentRefs returns all parentRefs that target a Gateway.
 func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
@@ -104,26 +66,6 @@ func (r *HTTPRouteAllowlistingReconciler) managedByValue() string {
 	return "ingress-allowlisting-controller"
 }
 
-// invalidLabelValue matches characters not allowed in k8s label values: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
-var invalidLabelValue = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
-
-func labelSafe(s string) string {
-	v := invalidLabelValue.ReplaceAllString(s, "_")
-	if len(v) > 63 {
-		v = v[:63]
-	}
-	return v
-}
-
-func (r *HTTPRouteAllowlistingReconciler) applyLabels(policy *istiosecurityv1.AuthorizationPolicy, ownerNamespace, ownerName string) {
-	if policy.Labels == nil {
-		policy.Labels = map[string]string{}
-	}
-	policy.Labels["app.kubernetes.io/managed-by"] = r.managedByValue()
-	policy.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"] = labelSafe(ownerNamespace)
-	policy.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"] = labelSafe(ownerName)
-}
-
 func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.DefaultLogger.WithContext(ctx).WithField("httproute", req.NamespacedName)
 
@@ -131,7 +73,7 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	if err := r.Get(ctx, req.NamespacedName, &httproute); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log.Infof("HTTPRoute %s being reconciled. Creating/updating allowlist...", httproute.GetName())
+	log.Infof("HTTPRoute %s being reconciled. Creating/updating writers...", httproute.GetName())
 
 	parentRefs := gatewayParentRefs(&httproute)
 	if len(parentRefs) == 0 {
@@ -145,7 +87,34 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			if ref.Namespace == nil || string(*ref.Namespace) == httproute.Namespace {
 				continue // merge only applies to cross-namespace refs
 			}
-			if err := r.reconcileMergedGateway(ctx, &httproute, ref, mergeKey, i); err != nil {
+			gatewayNS := string(*ref.Namespace)
+			gateway := &gatewayApiv1.Gateway{}
+			if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("gateway %s/%s not found, skipping parentRef", gatewayNS, ref.Name)
+				continue
+			}
+			gwClass := &gatewayApiv1.GatewayClass{}
+			if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, err
+				}
+				log.Infof("GatewayClass %s not found, skipping parentRef", gateway.Spec.GatewayClassName)
+				continue
+			}
+			writer, ok := r.L7Writers[string(gwClass.Spec.ControllerName)]
+			if !ok {
+				log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
+				continue
+			}
+			mw, ok := writer.(writers.MergeableL7PolicyWriter)
+			if !ok {
+				log.Infof("writer for controller %s does not support merge, skipping", gwClass.Spec.ControllerName)
+				continue
+			}
+			if err := r.reconcileMergedGateway(ctx, &httproute, gateway, mw, mergeKey, i); err != nil {
 				return ctrl.Result{}, err
 			}
 			i++
@@ -166,35 +135,36 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		hostnames = append(hostnames, string(h))
 	}
 
-	rules := buildAuthorizationRules(allowedIps, hostnames)
-
-	for _, pt := range policyTargets(&httproute) {
-		policy := &istiosecurityv1.AuthorizationPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: pt.name, Namespace: pt.namespace},
+	for i, ref := range parentRefs {
+		gatewayNS := httproute.Namespace
+		if ref.Namespace != nil {
+			gatewayNS = string(*ref.Namespace)
 		}
-		_, err = ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
-			if !pt.crossNamespace {
-				// Same-namespace: owner reference enables automatic GC when the HTTPRoute is deleted.
-				// Cross-namespace owner references are silently stripped by the API server; controller-runtime
-				// rejects them early, so we skip the call entirely.
-				if err := ctrl.SetControllerReference(&httproute, policy, r.Scheme); err != nil {
-					return err
-				}
+		gateway := &gatewayApiv1.Gateway{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return ctrl.Result{}, err
 			}
-			r.applyLabels(policy, httproute.Namespace, httproute.Name)
-			policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-				Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-				Rules:  rules,
-				TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-					{Name: pt.gatewayName, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
-				},
+			log.Infof("gateway %s/%s not found, skipping parentRef", gatewayNS, ref.Name)
+			continue
+		}
+		gwClass := &gatewayApiv1.GatewayClass{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return ctrl.Result{}, err
 			}
-			return nil
-		})
-		if err != nil {
+			log.Infof("GatewayClass %s not found, skipping parentRef", gateway.Spec.GatewayClassName)
+			continue
+		}
+		writer, ok := r.L7Writers[string(gwClass.Spec.ControllerName)]
+		if !ok {
+			log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
+			continue
+		}
+		if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil, i); err != nil {
 			return ctrl.Result{}, err
 		}
-		log.Infof("AuthorizationPolicy %s/%s created/updated for HTTPRoute %s", pt.namespace, pt.name, httproute.GetName())
+		log.Infof("AuthorizationPolicy created/updated for HTTPRoute %s parentRef %d", httproute.GetName(), i)
 	}
 
 	return ctrl.Result{}, nil
@@ -214,193 +184,64 @@ func cleanupRunnable(mgr ctrl.Manager, r *HTTPRouteAllowlistingReconciler) manag
 
 // runStartupCleanup lists all APs managed by this controller, checks whether the owning
 // HTTPRoute still exists and would still produce that AP, and deletes any that are orphaned.
-// This handles APs left behind by previous controller runs.
 func (r *HTTPRouteAllowlistingReconciler) runStartupCleanup(ctx context.Context) {
-	{
-		log := log.DefaultLogger.WithContext(ctx)
-		log.Infof("Running post-startup orphan cleanup for managed AuthorizationPolicies")
+	log := log.DefaultLogger.WithContext(ctx)
+	log.Infof("Running post-startup orphan cleanup for managed AuthorizationPolicies")
 
-		existing := &istiosecurityv1.AuthorizationPolicyList{}
-		if err := r.List(ctx, existing, client.MatchingLabels{
-			"app.kubernetes.io/managed-by": r.managedByValue(),
-		}); err != nil {
-			log.Errorf("startup cleanup: failed to list AuthorizationPolicies: %v", err)
-			return
-		}
+	allRoutes := &gatewayApiv1.HTTPRouteList{}
+	if err := r.APIReader.List(ctx, allRoutes); err != nil {
+		log.Errorf("startup cleanup: failed to list HTTPRoutes: %v", err)
+		return
+	}
 
-		// Safety check: list all HTTPRoutes once upfront. If the list call fails or returns
-		// empty while we have managed APs, the API server or cache may be in a degraded state.
-		// Abort rather than risk deleting valid APs based on a dirty read.
-		allRoutes := &gatewayApiv1.HTTPRouteList{}
-		if err := r.List(ctx, allRoutes); err != nil {
-			log.Errorf("startup cleanup: failed to list HTTPRoutes, aborting to avoid dirty-read deletions: %v", err)
-			return
+	for _, writer := range r.L7Writers {
+		managed, err := writer.ListManaged(ctx, r.managedByValue())
+		if err != nil {
+			log.Errorf("startup cleanup: failed to list managed policies: %v", err)
+			continue
 		}
-		if len(allRoutes.Items) == 0 && len(existing.Items) > 0 {
+		if len(allRoutes.Items) == 0 && len(managed) > 0 {
 			log.Infof("startup cleanup: no HTTPRoutes found but managed APs exist — skipping to avoid dirty-read deletions")
-			return
+			continue
 		}
-
-		for _, ap := range existing.Items {
-			ap := ap
-			ownerNS := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
-			ownerName := ap.Labels[r.CidrResolver.AnnotationPrefix+"/owner-name"]
-
-			if ownerNS == "merged" {
-				// Merge-mode AP: first check the cache (fast path); if not found there, confirm
-				// via direct API server read to rule out label-selector filtering.
-				found := false
-				for i := range allRoutes.Items {
-					if allRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
-						found = true
-						break
-					}
-				}
-				if found {
+		for _, obj := range managed {
+			obj := obj
+			if writer.IsOrphaned(obj, allRoutes.Items) {
+				if err := writer.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+					log.Errorf("startup cleanup: failed to delete %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
 					continue
 				}
-				// Cache returned nothing — confirm via API server before deleting
-				directRoutes := &gatewayApiv1.HTTPRouteList{}
-				if err := r.APIReader.List(ctx, directRoutes); err != nil {
-					log.Errorf("startup cleanup: API reader failed to list HTTPRoutes: %v", err)
-					return
-				}
-				for i := range directRoutes.Items {
-					if directRoutes.Items[i].Annotations[r.mergeAnnotation()] == ownerName {
-						found = true
-						break
-					}
-				}
-				if found {
-					continue
-				}
-			} else {
-				// Normal AP: check cache first; if the route is absent from cache, confirm via
-				// direct API server read — it may simply be outside the label selector.
-				route := &gatewayApiv1.HTTPRoute{}
-				err := r.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, route)
-				if client.IgnoreNotFound(err) != nil {
-					log.Errorf("startup cleanup: failed to get HTTPRoute %s/%s: %v", ownerNS, ownerName, err)
-					return
-				}
-				if err == nil && route.Annotations[r.mergeAnnotation()] == "" {
-					// Route is in cache and not in merge mode — check it still produces this AP
-					if routeProducesPolicy(route, ap.Namespace, ap.Name) {
-						continue
-					}
-				}
-				if err != nil {
-					// Not in cache — confirm via API server before deleting
-					directRoute := &gatewayApiv1.HTTPRoute{}
-					directErr := r.APIReader.Get(ctx, types.NamespacedName{Namespace: ownerNS, Name: ownerName}, directRoute)
-					if client.IgnoreNotFound(directErr) != nil {
-						log.Errorf("startup cleanup: API reader failed to get HTTPRoute %s/%s: %v", ownerNS, ownerName, directErr)
-						return
-					}
-					if directErr == nil {
-						// Route exists on API server but not in cache — outside label selector, keep AP
-						continue
-					}
-					// Confirmed 404 on API server — truly gone, fall through to delete
-				}
-				// Falls through if: confirmed gone, switched to merge, or no longer produces this AP
+				log.Infof("Startup cleanup: deleted orphaned policy %s/%s", obj.GetNamespace(), obj.GetName())
 			}
-
-			if err := r.Delete(ctx, ap); client.IgnoreNotFound(err) != nil {
-				log.Errorf("startup cleanup: failed to delete orphaned AP %s/%s: %v", ap.Namespace, ap.Name, err)
-				return
-			}
-			log.Infof("Startup cleanup: deleted orphaned AuthorizationPolicy %s/%s (owner: %s/%s)", ap.Namespace, ap.Name, ownerNS, ownerName)
 		}
 	}
 }
 
-func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, ref gatewayApiv1.ParentReference, mergeKey string, i int) error {
+func (r *HTTPRouteAllowlistingReconciler) reconcileMergedGateway(ctx context.Context, httproute *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, writer writers.MergeableL7PolicyWriter, mergeKey string, i int) error {
 	log := log.DefaultLogger.WithContext(ctx)
-	gatewayName := string(ref.Name)
-	gatewayNamespace := string(*ref.Namespace)
 
 	allRoutes := &gatewayApiv1.HTTPRouteList{}
 	if err := r.List(ctx, allRoutes); err != nil {
 		return err
 	}
 
-	seenIPs := map[string]struct{}{}
-	seenHosts := map[string]struct{}{}
-	var mergedIPs, mergedHosts []string
-
-	for i := range allRoutes.Items {
-		sibling := &allRoutes.Items[i]
+	var siblings []*gatewayApiv1.HTTPRoute
+	for idx := range allRoutes.Items {
+		sibling := &allRoutes.Items[idx]
 		if sibling.Annotations[r.mergeAnnotation()] != mergeKey {
 			continue
 		}
-		if !httproutePointsToGateway(sibling, gatewayName, gatewayNamespace) {
+		if !httproutePointsToGateway(sibling, gateway.Name, gateway.Namespace) {
 			continue
 		}
-
-		ips, err := r.CidrResolver.GetCidrsFromObject(ctx, sibling)
-		if err == r.CidrResolver.AnnotationNotFoundError() {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		for _, ip := range ips {
-			if _, seen := seenIPs[ip]; !seen {
-				seenIPs[ip] = struct{}{}
-				mergedIPs = append(mergedIPs, ip)
-			}
-		}
-		for _, h := range sibling.Spec.Hostnames {
-			host := string(h)
-			if _, seen := seenHosts[host]; !seen {
-				seenHosts[host] = struct{}{}
-				mergedHosts = append(mergedHosts, host)
-			}
-		}
+		siblings = append(siblings, sibling)
 	}
 
-	if len(mergedIPs) == 0 {
-		log.Infof("No CIDRs found for merge group %q → gateway %s/%s, skipping", mergeKey, gatewayNamespace, gatewayName)
-		return nil
-	}
-
-	policyName := mergeKey
-	if i > 0 {
-		policyName = fmt.Sprintf("%s-%d", mergeKey, i)
-	}
-	policy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: gatewayNamespace},
-	}
-	_, err := ctrl.CreateOrUpdate(ctx, r.Client, policy, func() error {
-		r.applyLabels(policy, "merged", mergeKey)
-		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-			Rules:  buildAuthorizationRules(mergedIPs, mergedHosts),
-			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-				{Name: gatewayName, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
-			},
-		}
-		return nil
-	})
-	if err != nil {
+	if err := writer.ApplyMerged(ctx, gateway, siblings, mergeKey, i); err != nil {
 		return err
 	}
-	log.Infof("Merged AuthorizationPolicy %s/%s created/updated for merge group %q", gatewayNamespace, policyName, mergeKey)
+	log.Infof("Merged AuthorizationPolicy created/updated for merge group %q → gateway %s/%s", mergeKey, gateway.Namespace, gateway.Name)
 	return nil
-}
-
-// routeProducesPolicy reports whether the non-merge reconcile path for route would generate
-// an AuthorizationPolicy at the given {namespace, name}. Used by startup cleanup to decide
-// whether an existing AP is still valid or has become orphaned (e.g. parentRef removed,
-// route switched to merge mode, or index shift after reordering parentRefs).
-func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
-	for _, pt := range policyTargets(route) {
-		if pt.namespace == policyNamespace && pt.name == policyName {
-			return true
-		}
-	}
-	return false
 }
 
 // mergeSiblingEnqueuer returns an EventHandler that, when an HTTPRoute's merge annotation
@@ -438,22 +279,6 @@ func httproutePointsToGateway(httproute *gatewayApiv1.HTTPRoute, gatewayName, ga
 		}
 	}
 	return false
-}
-
-func buildAuthorizationRules(allowedIPs, hostnames []string) []*istioApiSecurityV1.Rule {
-	rules := []*istioApiSecurityV1.Rule{
-		{
-			From: []*istioApiSecurityV1.Rule_From{
-				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: allowedIPs}},
-			},
-		},
-	}
-	if len(hostnames) > 0 {
-		rules[0].To = []*istioApiSecurityV1.Rule_To{
-			{Operation: &istioApiSecurityV1.Operation{Hosts: hostnames}},
-		}
-	}
-	return rules
 }
 
 func hasAllowlistAnnotation(annotationPrefix string, obj client.Object) bool {

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -14,9 +14,11 @@ import (
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -472,17 +474,23 @@ func TestGranularityRule(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
 	assert.NoError(t, err)
 
-	// One AP per rule: /api and /admin
-	ap1 := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route-api", Namespace: "ns"}, ap1)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"/api"}, ap1.Spec.Rules[0].To[0].Operation.Paths)
-	assert.ElementsMatch(t, []string{"example.com"}, ap1.Spec.Rules[0].To[0].Operation.Hosts)
+	// One AP per rule: /api and /admin — list all and verify by path content.
+	apList := &istiosecurityv1.AuthorizationPolicyList{}
+	err = k8sClient.List(context.Background(), apList, client.InNamespace("ns"))
+	require.NoError(t, err)
+	require.Len(t, apList.Items, 2, "expected two APs, one per rule")
 
-	ap2 := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route-admin", Namespace: "ns"}, ap2)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"/admin"}, ap2.Spec.Rules[0].To[0].Operation.Paths)
+	var pathSets [][]string
+	for _, ap := range apList.Items {
+		require.Len(t, ap.Spec.Rules, 1)
+		require.Len(t, ap.Spec.Rules[0].To, 1)
+		pathSets = append(pathSets, ap.Spec.Rules[0].To[0].Operation.Paths)
+		assert.ElementsMatch(t, []string{"example.com"}, ap.Spec.Rules[0].To[0].Operation.Hosts)
+	}
+	assert.ElementsMatch(t, [][]string{
+		{"/api", "/api/*"},
+		{"/admin", "/admin/*"},
+	}, pathSets)
 }
 
 func TestGranularityHost(t *testing.T) {
@@ -522,7 +530,7 @@ func TestGatewayParentRefs(t *testing.T) {
 
 	t.Run("no parentRefs returns empty slice", func(t *testing.T) {
 		hr := &gatewayApiv1.HTTPRoute{}
-		assert.Empty(t, gatewayParentRefs(hr))
+		assert.Empty(t, gateway.GatewayParentRefs(hr))
 	})
 
 	t.Run("explicit kind=Gateway and group matches", func(t *testing.T) {
@@ -531,7 +539,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &gwKind, Name: "gw"},
 			}},
 		}}
-		refs := gatewayParentRefs(hr)
+		refs := gateway.GatewayParentRefs(hr)
 		assert.Len(t, refs, 1)
 		assert.Equal(t, gatewayApiv1.ObjectName("gw"), refs[0].Name)
 	})
@@ -542,7 +550,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Name: "gw"},
 			}},
 		}}
-		assert.Len(t, gatewayParentRefs(hr), 1)
+		assert.Len(t, gateway.GatewayParentRefs(hr), 1)
 	})
 
 	t.Run("non-Gateway kind is skipped", func(t *testing.T) {
@@ -551,7 +559,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &svcKind, Name: "svc"},
 			}},
 		}}
-		assert.Empty(t, gatewayParentRefs(hr))
+		assert.Empty(t, gateway.GatewayParentRefs(hr))
 	})
 
 	t.Run("non-gateway group is skipped", func(t *testing.T) {
@@ -560,7 +568,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &coreGroup, Kind: &gwKind, Name: "gw"},
 			}},
 		}}
-		assert.Empty(t, gatewayParentRefs(hr))
+		assert.Empty(t, gateway.GatewayParentRefs(hr))
 	})
 
 	t.Run("multiple Gateway parentRefs all returned, non-Gateway skipped", func(t *testing.T) {
@@ -571,7 +579,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &gwKind, Name: "second-gw"},
 			}},
 		}}
-		refs := gatewayParentRefs(hr)
+		refs := gateway.GatewayParentRefs(hr)
 		assert.Len(t, refs, 2)
 		assert.Equal(t, gatewayApiv1.ObjectName("first-gw"), refs[0].Name)
 		assert.Equal(t, gatewayApiv1.ObjectName("second-gw"), refs[1].Name)
@@ -583,7 +591,7 @@ func TestGatewayParentRefs(t *testing.T) {
 				{Group: &gwGroup, Kind: &gwKind, Name: "gw", Namespace: &ns},
 			}},
 		}}
-		refs := gatewayParentRefs(hr)
+		refs := gateway.GatewayParentRefs(hr)
 		assert.Len(t, refs, 1)
 		assert.Equal(t, &ns, refs[0].Namespace)
 	})
@@ -1352,6 +1360,59 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 	merged := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "myapp", Namespace: "gw-ns"}, merged)
 	assert.NoError(t, err, "merged AP should exist")
+}
+
+// TestStartupCleanupGranularityHost verifies that an AP created by a granularity=host route
+// (base name, no path suffix) is NOT deleted by startup cleanup — the full reconcile+cleanup
+// loop must recognise it as live.
+func TestStartupCleanupGranularityHost(t *testing.T) {
+	pathMatch := gatewayApiv1.PathMatchPathPrefix
+	pathVal := "/api"
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "localnet",
+				"ipam.adevinta.com/granularity":     "host",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("my-gw", "")},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+			Rules: []gatewayApiv1.HTTPRouteRule{
+				{Matches: []gatewayApiv1.HTTPRouteMatch{
+					{Path: &gatewayApiv1.HTTPPathMatch{Type: &pathMatch, Value: &pathVal}},
+				}},
+			},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// Reconcile creates the AP.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+
+	// AP must be at base name (no path suffix) for granularity=host.
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, ap)
+	require.NoError(t, err, "AP at base name must exist after reconcile")
+	assert.Nil(t, ap.Spec.Rules[0].To[0].Operation.Paths, "granularity=host AP must have no path restriction")
+
+	// Startup cleanup must NOT delete the live AP.
+	reconciler.runStartupCleanup(context.Background())
+
+	surviving := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, surviving)
+	assert.NoError(t, err, "granularity=host AP must survive startup cleanup")
 }
 
 func TestLabelSafe(t *testing.T) {

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -115,7 +115,7 @@ func TestReconcileHTTPRoute(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 
 	assert.Equal(t, istioApiSecurityV1.AuthorizationPolicy_ALLOW, generatedPolicy.Spec.Action)
@@ -166,7 +166,7 @@ func TestReconcileHTTPRouteNoHostnames(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.Nil(t, generatedPolicy.Spec.Rules[0].To, "To rule should be absent when no hostnames")
 }
@@ -237,16 +237,16 @@ func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// Policy should be in gateway-namespace with name = <httproute.Namespace>-<httproute.Name> (single parent, no suffix)
+	// Policy should be in gateway-namespace with name = {gateway}-{route.Namespace}-{route.Name}
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gateway-namespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "gateway-namespace"}, generatedPolicy)
 	assert.NoError(t, err, "AuthorizationPolicy should be created in cross-namespace")
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 	assert.Equal(t, "my-gateway", generatedPolicy.Spec.TargetRefs[0].Name)
 
 	// Should NOT be in the httproute's namespace
 	notExpectedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "mynamespace"}, notExpectedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "mynamespace"}, notExpectedPolicy)
 	assert.True(t, apierrors.IsNotFound(err), "AuthorizationPolicy should NOT be in the HTTPRoute namespace")
 }
 
@@ -278,7 +278,7 @@ func TestReconcileHTTPRouteWithClusterCIDR(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t,
 		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8", "15.13.12.0/24"},
@@ -313,7 +313,7 @@ func TestReconcileHTTPRoutePartialCIDRsNotFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t,
 		[]string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"},
@@ -341,7 +341,7 @@ func TestReconcileHTTPRouteAllCIDRsNotFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"127.0.0.2/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 
@@ -375,7 +375,7 @@ func TestReconcileHTTPRouteTargetRefs(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "specific-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.Len(t, generatedPolicy.Spec.TargetRefs, 1)
 	ref := generatedPolicy.Spec.TargetRefs[0]
@@ -424,10 +424,94 @@ func TestReconcileHTTPRouteWithAnnotationSpaces(t *testing.T) {
 	assert.NoError(t, err)
 
 	generatedPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, generatedPolicy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"192.168.0.0/16", "1.1.1.1/32"}, generatedPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 }
+
+func newHTTPRouteWithPaths(name, ns, gwName, granularity string, paths ...string) *gatewayApiv1.HTTPRoute {
+	var rules []gatewayApiv1.HTTPRouteRule
+	for _, p := range paths {
+		p := p
+		pathMatch := gatewayApiv1.PathMatchPathPrefix
+		rules = append(rules, gatewayApiv1.HTTPRouteRule{
+			Matches: []gatewayApiv1.HTTPRouteMatch{{
+				Path: &gatewayApiv1.HTTPPathMatch{Type: &pathMatch, Value: &p},
+			}},
+		})
+	}
+	annotations := map[string]string{
+		"ipam.adevinta.com/allowlist-group": "localnet",
+	}
+	if granularity != "" {
+		annotations["ipam.adevinta.com/granularity"] = granularity
+	}
+	return &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: ns, Annotations: annotations},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef(gwName, "")},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+			Rules:     rules,
+		},
+	}
+}
+
+func TestGranularityRule(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "rule", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.NoError(t, err)
+
+	// One AP per rule: /api and /admin
+	ap1 := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route-api", Namespace: "ns"}, ap1)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"/api"}, ap1.Spec.Rules[0].To[0].Operation.Paths)
+	assert.ElementsMatch(t, []string{"example.com"}, ap1.Spec.Rules[0].To[0].Operation.Hosts)
+
+	ap2 := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route-admin", Namespace: "ns"}, ap2)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"/admin"}, ap2.Spec.Rules[0].To[0].Operation.Paths)
+}
+
+func TestGranularityHost(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	httproute := newHTTPRouteWithPaths("my-route", "ns", "my-gw", "host", "/api", "/admin")
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.NoError(t, err)
+
+	// Single AP, host matched, no path restriction
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route", Namespace: "ns"}, ap)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"example.com"}, ap.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Nil(t, ap.Spec.Rules[0].To[0].Operation.Paths, "host granularity must not set paths")
+
+	// No per-rule APs created
+	apRule := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gw-my-route-api", Namespace: "ns"}, apRule)
+	assert.True(t, apierrors.IsNotFound(err), "granularity=host must not create per-rule APs")
+}
+
 
 func TestGatewayParentRefs(t *testing.T) {
 	gwGroup := gatewayApiv1.Group("gateway.networking.k8s.io")
@@ -532,16 +616,16 @@ func TestReconcileHTTPRouteMultipleGateways(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// First gateway: no suffix → "test"
+	// First gateway: AP name = {gateway}-{route} = "internal-gateway-test"
 	policy0 := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, policy0)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "internal-gateway-test", Namespace: "mynamespace"}, policy0)
 	assert.NoError(t, err)
 	assert.Equal(t, "internal-gateway", policy0.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, policy0.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 
-	// Second gateway: suffix "-1" → "test-1"
+	// Second gateway: AP name = {gateway}-{route} = "external-gateway-test"
 	policy1 := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test-1", Namespace: "mynamespace"}, policy1)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "external-gateway-test", Namespace: "mynamespace"}, policy1)
 	assert.NoError(t, err)
 	assert.Equal(t, "external-gateway", policy1.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, policy1.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
@@ -574,19 +658,81 @@ func TestReconcileHTTPRouteMultipleGatewaysCrossNamespace(t *testing.T) {
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
 	assert.NoError(t, err)
 
-	// First (same-namespace): no suffix → "test"
+	// First (same-namespace): AP name = "internal-gateway-test"
 	sameNsPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, sameNsPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "internal-gateway-test", Namespace: "mynamespace"}, sameNsPolicy)
 	assert.NoError(t, err)
 	assert.Equal(t, "internal-gateway", sameNsPolicy.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, sameNsPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
 
-	// Second (cross-namespace): suffix "-1" → "mynamespace-test-1"
+	// Second (cross-namespace): AP name = "external-gateway-mynamespace-test" in gateway-namespace
 	crossNsPolicy := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test-1", Namespace: "gateway-namespace"}, crossNsPolicy)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "external-gateway-mynamespace-test", Namespace: "gateway-namespace"}, crossNsPolicy)
 	assert.NoError(t, err)
 	assert.Equal(t, "external-gateway", crossNsPolicy.Spec.TargetRefs[0].Name)
 	assert.ElementsMatch(t, []string{"10.0.0.0/8"}, crossNsPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestValidateMergeKey(t *testing.T) {
+	valid := []string{
+		"chaos-monkey",
+		"myapp",
+		"a",
+		"a1b2c3",
+		"my-service-v2",
+		"my.app.example.com",
+		"api.service.example.com",
+		strings.Repeat("a", 253),
+	}
+	for _, key := range valid {
+		assert.NoError(t, validateMergeKey(key), "expected %q to be valid", key)
+	}
+
+	invalid := []string{
+		"",
+		"MyApp",          // uppercase
+		"my_app",         // underscore
+		"my/app",         // slash
+		"-myapp",         // leading hyphen
+		"myapp-",         // trailing hyphen
+		"my app",         // space
+		strings.Repeat("a", 254), // too long
+	}
+	for _, key := range invalid {
+		assert.Error(t, validateMergeKey(key), "expected %q to be invalid", key)
+	}
+}
+
+func TestReconcileHTTPRouteMergeInvalidKey(t *testing.T) {
+	// A route with an invalid merge key must return an error — not silently create
+	// an AP with an invalid name that the API server would reject opaquely.
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "INVALID_KEY!", // uppercase + special chars
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "my-gw", Namespace: &gwNS},
+			}},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gw", "gw-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	assert.Error(t, err, "invalid merge key must return an error")
+	assert.Contains(t, err.Error(), "INVALID_KEY!")
 }
 
 func TestReconcileHTTPRouteMerge(t *testing.T) {
@@ -646,14 +792,24 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err, "merged policy should be created with name = merge key")
 
-	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+	// Two-level grouping: routes with different CIDR sets each get their own Rule.
+	var allIPs, allHosts []string
+	for _, rule := range policy.Spec.Rules {
+		for _, from := range rule.From {
+			allIPs = append(allIPs, from.Source.RemoteIpBlocks...)
+		}
+		for _, to := range rule.To {
+			allHosts = append(allHosts, to.Operation.Hosts...)
+		}
+	}
+	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, allIPs)
 	assert.ElementsMatch(t,
 		[]string{"chaos-monkey.public.ns-staging00.example.com", "chaos-monkey.public.ns-staging01.example.com"},
-		policy.Spec.Rules[0].To[0].Operation.Hosts,
+		allHosts,
 	)
 	assert.Equal(t, "cross-namespace-public", policy.Spec.TargetRefs[0].Name)
 	assert.Equal(t, "ingress-allowlisting-controller", policy.Labels["app.kubernetes.io/managed-by"])
-	assert.Equal(t, "merged", policy.Labels["ipam.adevinta.com/owner-namespace"])
+	assert.Equal(t, "MERGED", policy.Labels["ipam.adevinta.com/owner-namespace"])
 	assert.Equal(t, "chaos-monkey", policy.Labels["ipam.adevinta.com/owner-name"])
 }
 
@@ -718,14 +874,23 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 
-	// Confirm both hosts are present
+	// Confirm both hosts are present (across all rules — two-level grouping gives each CIDR set its own rule).
+	allPolicyHosts := func(p *istiosecurityv1.AuthorizationPolicy) []string {
+		var hosts []string
+		for _, rule := range p.Spec.Rules {
+			for _, to := range rule.To {
+				hosts = append(hosts, to.Operation.Hosts...)
+			}
+		}
+		return hosts
+	}
 	policy := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"chaos-monkey.public.ns-staging00.example.com",
 		"chaos-monkey.public.ns-staging01.example.com",
-	}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	}, allPolicyHosts(policy))
 
 	// Step 2: route01 changes its merge key to "bar"
 	route01.Annotations["ipam.adevinta.com/merge"] = "bar"
@@ -748,10 +913,11 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	// chaos-monkey AP must now only contain route00's hostname
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, policy)
 	assert.NoError(t, err)
-	assert.NotContains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
+	allHosts := allPolicyHosts(policy)
+	assert.NotContains(t, allHosts,
 		"chaos-monkey.public.ns-staging01.example.com",
 		"route01 left the merge group — its hostname must not appear in the chaos-monkey AP")
-	assert.Contains(t, policy.Spec.Rules[0].To[0].Operation.Hosts,
+	assert.Contains(t, allHosts,
 		"chaos-monkey.public.ns-staging00.example.com",
 		"route00 is still in the merge group — its hostname must be present")
 }
@@ -885,10 +1051,10 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 	}})
 	assert.NoError(t, err)
 
-	// Normal cross-namespace naming: <namespace>-<name>
+	// Normal cross-namespace naming: {gateway}-{routeNS}-{routeName}
 	policy := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{
-		Name:      "ns-staging00-chaos-monkey.public.ns-staging00.example.com",
+		Name:      "cross-namespace-public-ns-staging00-chaos-monkey.public.ns-staging00.example.com",
 		Namespace: "ns-infra",
 	}, policy)
 	assert.NoError(t, err)
@@ -898,6 +1064,69 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 	merged := &istiosecurityv1.AuthorizationPolicy{}
 	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "chaos-monkey", Namespace: "ns-infra"}, merged)
 	assert.True(t, apierrors.IsNotFound(err), "no merged policy should be created without merge annotation")
+}
+
+func TestReconcileHTTPRouteMergeSameNamespace(t *testing.T) {
+	// Two routes in the same namespace point to a same-namespace gateway (no Namespace on parentRef).
+	// Both carry merge=myapp — the controller must merge them just like it does cross-namespace.
+	cidr0 := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "my-ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	route0 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "svc-a", Namespace: "my-ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "myapp",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				parentRef("my-gateway", ""), // no namespace — same-namespace ref
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"svc-a.example.com"},
+		},
+	}
+	route1 := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "svc-b", Namespace: "my-ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "myapp",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				parentRef("my-gateway", ""), // no namespace — same-namespace ref
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"svc-b.example.com"},
+		},
+	}
+
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "my-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr0, route0, route1, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
+		Name: "svc-a", Namespace: "my-ns",
+	}})
+	assert.NoError(t, err)
+
+	// Merged AP lives in the same namespace as the gateway (= route namespace here).
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "myapp", Namespace: "my-ns"}, policy)
+	assert.NoError(t, err, "same-namespace merge must create AP named by merge key")
+
+	var allHosts []string
+	for _, rule := range policy.Spec.Rules {
+		for _, to := range rule.To {
+			allHosts = append(allHosts, to.Operation.Hosts...)
+		}
+	}
+	assert.ElementsMatch(t, []string{"svc-a.example.com", "svc-b.example.com"}, allHosts)
+	assert.Equal(t, "my-gateway", policy.Spec.TargetRefs[0].Name)
 }
 
 func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
@@ -926,7 +1155,7 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 		assert.NoError(t, err)
 
 		policy := &istiosecurityv1.AuthorizationPolicy{}
-		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, policy)
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-test", Namespace: "mynamespace"}, policy)
 		assert.NoError(t, err)
 
 		assert.Len(t, policy.OwnerReferences, 1)
@@ -954,7 +1183,7 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 		assert.NoError(t, err)
 
 		policy := &istiosecurityv1.AuthorizationPolicy{}
-		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gateway-namespace"}, policy)
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "gateway-namespace"}, policy)
 		assert.NoError(t, err)
 		assert.Empty(t, policy.OwnerReferences, "cross-namespace AP cannot have owner reference")
 	})
@@ -1004,7 +1233,7 @@ func TestStartupOrphanCleanup(t *testing.T) {
 
 	// Current AP should still exist
 	current := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, current)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "gateway-a-test", Namespace: "mynamespace"}, current)
 	assert.NoError(t, err)
 }
 
@@ -1094,7 +1323,7 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 	// Old AP from before merge was added — owner is the HTTPRoute (still exists!)
 	oldAP := &istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "mynamespace-test", Namespace: "gw-ns",
+			Name: "my-gateway-mynamespace-test", Namespace: "gw-ns",
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by":      "ingress-allowlisting-controller",
 				"ipam.adevinta.com/owner-namespace": "mynamespace",
@@ -1116,7 +1345,7 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 
 	// Old cross-namespace AP should be deleted — route now uses merge mode
 	stale := &istiosecurityv1.AuthorizationPolicy{}
-	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "mynamespace-test", Namespace: "gw-ns"}, stale)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway-mynamespace-test", Namespace: "gw-ns"}, stale)
 	assert.True(t, apierrors.IsNotFound(err), "old non-merge AP should be deleted after merge annotation added")
 
 	// New merged AP should exist
@@ -1136,7 +1365,7 @@ func TestLabelSafe(t *testing.T) {
 		{"chaos-monkey.public.ns-staging00.example.com", "chaos-monkey.public.ns-staging00.example.com"},
 		{"namespace/name", "namespace_name"},
 		{"foo*bar", "foo_bar"},
-		{"merged", "merged"},
+		{"MERGED", "MERGED"},
 		{strings.Repeat("a", 70), strings.Repeat("a", 63)},
 	}
 	for _, tc := range tests {
@@ -1146,21 +1375,26 @@ func TestLabelSafe(t *testing.T) {
 
 func TestAuthorizationPolicyNameMaxLength(t *testing.T) {
 	// Kubernetes resource names are DNS subdomains: max 253 chars.
-	// Namespace max = 63, name max = 63.
-	// Index suffix is only appended for the 2nd+ parentRef (i > 0).
-	// Worst case: cross-namespace, index 99 → <63>-<63>-99 = 63+1+63+1+2 = 130 chars — well under 253.
+	// Namespace max = 63, name max = 63, gateway name max = 63.
+	// Format: {gateway}-{route}                           (same-namespace)
+	//         {gateway}-{routeNS}-{routeName}             (cross-namespace)
+	//         {gateway}-{route}-{pathSafe}                (same-namespace, with path)
+	//         {gateway}-{routeNS}-{routeName}-{pathSafe}  (cross-namespace, with path)
+	// Worst case: cross-namespace with path → 63+1+63+1+63+1+63 = 255, truncation not implemented
+	// but k8s names are limited to 253. In practice gateway/route/NS names are much shorter.
+	maxGW := strings.Repeat("g", 63)
 	maxNS := strings.Repeat("n", 63)
 	maxName := strings.Repeat("a", 63)
 
-	t.Run("same-namespace with suffix stays under 253", func(t *testing.T) {
-		// <name>-<index>  →  63 + 1 + 2 = 66
-		result := fmt.Sprintf("%s-%d", maxName, 99)
+	t.Run("same-namespace stays under 253", func(t *testing.T) {
+		// {gw}-{name}  →  63 + 1 + 63 = 127
+		result := fmt.Sprintf("%s-%s", maxGW, maxName)
 		assert.LessOrEqual(t, len(result), 253)
 	})
 
-	t.Run("cross-namespace with suffix stays under 253", func(t *testing.T) {
-		// <namespace>-<name>-<index>  →  63 + 1 + 63 + 1 + 2 = 130
-		result := fmt.Sprintf("%s-%s-%d", maxNS, maxName, 99)
+	t.Run("cross-namespace stays under 253", func(t *testing.T) {
+		// {gw}-{ns}-{name}  →  63 + 1 + 63 + 1 + 63 = 191
+		result := fmt.Sprintf("%s-%s-%s", maxGW, maxNS, maxName)
 		assert.LessOrEqual(t, len(result), 253)
 	})
 }

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -14,6 +14,7 @@ import (
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/writers"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -27,12 +28,33 @@ import (
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+// newIstioGatewayClass creates an Istio GatewayClass with the given name.
+func newIstioGatewayClass(name string) *gatewayApiv1.GatewayClass {
+	return &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: name},
+		Spec: gatewayApiv1.GatewayClassSpec{
+			ControllerName: gatewayApiv1.GatewayController(writers.IstioControllerName),
+		},
+	}
+}
+
+// newTestGateway creates a Gateway with the given name, namespace, and GatewayClassName.
+func newTestGateway(name, namespace, className string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: gatewayApiv1.ObjectName(className)},
+	}
+}
+
 func newHTTPRouteReconciler(t *testing.T, k8sClient client.Client, scheme *runtime.Scheme) *HTTPRouteAllowlistingReconciler {
 	t.Helper()
 	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	l7Writers := writers.L7WriterRegistry{
+		writers.IstioControllerName: writers.NewIstioL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+	}
 	// In tests, APIReader uses the same fake client — no label-selector filtering in tests
 	// so the cache and API reader are equivalent.
-	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, APIReader: k8sClient, CidrResolver: resolver, Scheme: scheme}
+	return &HTTPRouteAllowlistingReconciler{Client: k8sClient, APIReader: k8sClient, CidrResolver: resolver, Scheme: scheme, L7Writers: l7Writers}
 }
 
 // parentRef builds a Gateway ParentReference. Pass ns="" for same-namespace (no Namespace field set).
@@ -84,7 +106,9 @@ func TestReconcileHTTPRoute(t *testing.T) {
 			Hostnames: []gatewayApiv1.Hostname{"example.com", "www.example.com"},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, globalCidrs).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, globalCidrs, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -133,7 +157,9 @@ func TestReconcileHTTPRouteNoHostnames(t *testing.T) {
 			// no Hostnames
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -203,7 +229,9 @@ func TestReconcileHTTPRouteCrossNamespace(t *testing.T) {
 			Hostnames: []gatewayApiv1.Hostname{"example.com"},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "gateway-namespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -241,7 +269,9 @@ func TestReconcileHTTPRouteWithClusterCIDR(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, globalNet, anotherGlobalNet).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, globalNet, anotherGlobalNet, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -274,7 +304,9 @@ func TestReconcileHTTPRoutePartialCIDRsNotFound(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -300,7 +332,9 @@ func TestReconcileHTTPRouteAllCIDRsNotFound(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -332,7 +366,9 @@ func TestReconcileHTTPRouteTargetRefs(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("specific-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -379,7 +415,9 @@ func TestReconcileHTTPRouteWithAnnotationSpaces(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, dnssourceCidrs, httproute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -485,7 +523,10 @@ func TestReconcileHTTPRouteMultipleGateways(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gwInternal := newTestGateway("internal-gateway", "mynamespace", "istio")
+	gwExternal := newTestGateway("external-gateway", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gwInternal, gwExternal).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -524,7 +565,10 @@ func TestReconcileHTTPRouteMultipleGatewaysCrossNamespace(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gwInternal := newTestGateway("internal-gateway", "mynamespace", "istio")
+	gwExternal := newTestGateway("external-gateway", "gateway-namespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, httproute, gwClass, gwInternal, gwExternal).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -547,11 +591,11 @@ func TestReconcileHTTPRouteMultipleGatewaysCrossNamespace(t *testing.T) {
 
 func TestReconcileHTTPRouteMerge(t *testing.T) {
 	cidrStaging00 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	cidrStaging01 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging01"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"5.6.7.8/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -560,7 +604,7 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -575,7 +619,7 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -587,7 +631,9 @@ func TestReconcileHTTPRouteMerge(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -618,11 +664,11 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 	//         route00 is NOT reconciled because nothing triggered it.
 	// Bug: the chaos-monkey AP still contains route01's hostname because route00 was never re-reconciled.
 	cidrStaging00 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	cidrStaging01 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging01"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"5.6.7.8/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -630,7 +676,7 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -645,7 +691,7 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging01.example.com", Namespace: "ns-staging01",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -657,7 +703,9 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, route00, route01, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	// Step 1: reconcile both routes — AP gets both hostnames
@@ -711,11 +759,11 @@ func TestReconcileHTTPRouteMergeStaleHostAfterKeyChange(t *testing.T) {
 func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 	sharedCIDR := []string{"1.2.3.4/32", "5.6.7.8/32"}
 	cidrStaging00 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: sharedCIDR},
 	}
 	cidrStaging01 := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging01"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging01"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: sharedCIDR},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -724,7 +772,7 @@ func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "chaos-monkey.public." + ns + ".example.com", Namespace: ns,
 				Annotations: map[string]string{
-					"ipam.adevinta.com/allowlist-group": "allowlist",
+					"ipam.adevinta.com/allowlist-group": "writers",
 					"ipam.adevinta.com/merge":           "chaos-monkey",
 				},
 			},
@@ -735,7 +783,9 @@ func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 			},
 		}
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, makeRoute("ns-staging00"), makeRoute("ns-staging01")).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidrStaging00, cidrStaging01, makeRoute("ns-staging00"), makeRoute("ns-staging01"), gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -751,7 +801,7 @@ func TestReconcileHTTPRouteMergeDeduplicatesIPs(t *testing.T) {
 
 func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 	cidr := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -759,7 +809,7 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "chaos-monkey",
 			},
 		},
@@ -775,7 +825,7 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "other-service.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 				"ipam.adevinta.com/merge":           "other-service",
 			},
 		},
@@ -786,7 +836,9 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 			Hostnames: []gatewayApiv1.Hostname{"other-service.public.ns-staging00.example.com"},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, otherRoute).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, otherRoute, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -806,7 +858,7 @@ func TestReconcileHTTPRouteMergeDifferentKeyNotMerged(t *testing.T) {
 
 func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T) {
 	cidr := &ipamv1alpha1.CIDRs{
-		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-staging00"},
+		ObjectMeta: v1.ObjectMeta{Name: "writers", Namespace: "ns-staging00"},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
 	}
 	gwNS := gatewayApiv1.Namespace("ns-infra")
@@ -814,7 +866,7 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 		ObjectMeta: v1.ObjectMeta{
 			Name: "chaos-monkey.public.ns-staging00.example.com", Namespace: "ns-staging00",
 			Annotations: map[string]string{
-				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/allowlist-group": "writers",
 			},
 		},
 		Spec: gatewayApiv1.HTTPRouteSpec{
@@ -823,7 +875,9 @@ func TestReconcileHTTPRouteMergeWithoutMergeAnnotationIsIndependent(t *testing.T
 			}},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route).Build()
+	gwClass2 := newIstioGatewayClass("istio")
+	gw2 := newTestGateway("cross-namespace-public", "ns-infra", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, gwClass2, gw2).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{
@@ -863,7 +917,9 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 				},
 			},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute).Build()
+		gwClass := newIstioGatewayClass("istio")
+		gw := newTestGateway("my-gateway", "mynamespace", "istio")
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
 		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -889,7 +945,9 @@ func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 				},
 			},
 		}
-		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute).Build()
+		gwClass := newIstioGatewayClass("istio")
+		gw := newTestGateway("my-gateway", "gateway-namespace", "istio")
+		k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, gwClass, gw).Build()
 		reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -928,7 +986,9 @@ func TestStartupOrphanCleanup(t *testing.T) {
 			},
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, orphan).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("gateway-a", "mynamespace", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, orphan, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -1043,7 +1103,9 @@ func TestStartupCleanupRemovesOldAPWhenMergeAdded(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, oldAP).Build()
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("my-gateway", "gw-ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, httproute, oldAP, gwClass, gw).Build()
 	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
@@ -1078,7 +1140,7 @@ func TestLabelSafe(t *testing.T) {
 		{strings.Repeat("a", 70), strings.Repeat("a", 63)},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.want, labelSafe(tc.input), "input: %q", tc.input)
+		assert.Equal(t, tc.want, writers.LabelSafe(tc.input), "input: %q", tc.input)
 	}
 }
 

--- a/pkg/controllers/internal/gateway.go
+++ b/pkg/controllers/internal/gateway.go
@@ -1,0 +1,27 @@
+// Package gateway provides shared Gateway API helpers used by both the controllers
+// and writers packages. It exists as a separate internal package to break the
+// import cycle: controllers imports writers, so writers cannot import controllers.
+// Any logic that both layers need must live here instead.
+package gateway
+
+import gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+// GatewayParentRefs returns only the parentRefs from an HTTPRoute that target a Gateway,
+// filtering out any other kinds (e.g. Service). Used in two places:
+//   - httproute_controller: to discover which Gateways the route is attached to and
+//     drive the reconcile loop (one AP per gateway).
+//   - istio_l7 (policyTargetsForRoute): to predict the exact AP names the reconcile loop
+//     would produce, so orphan detection can do exact matching without prefix heuristics.
+func GatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
+	var refs []gatewayApiv1.ParentReference
+	for _, ref := range httproute.Spec.ParentRefs {
+		if ref.Kind != nil && *ref.Kind != "Gateway" {
+			continue
+		}
+		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}

--- a/pkg/controllers/writers/interfaces.go
+++ b/pkg/controllers/writers/interfaces.go
@@ -10,15 +10,28 @@ import (
 
 const IstioControllerName = "istio.io/gateway-controller"
 
+// Permission represents a single Kubernetes RBAC permission required by a writer.
+type Permission struct {
+	Group    string
+	Resource string
+	Verb     string
+}
+
+// PermissionProvider is an optional interface a writer can implement to declare
+// the RBAC permissions it needs. checkRBAC in main.go uses this for preflight checks.
+type PermissionProvider interface {
+	RequiredPermissions() []Permission
+}
+
 // L4PolicyWriter creates gateway-level (L4) allow policies.
 type L4PolicyWriter interface {
-	Apply(ctx context.Context, gateway *gatewayApiv1.Gateway, ips []string) error
+	Apply(ctx context.Context, scheme *runtime.Scheme, gateway *gatewayApiv1.Gateway, ips []string) error
 	Delete(ctx context.Context, gateway *gatewayApiv1.Gateway) error
 }
 
 // L7PolicyWriter creates route-level (L7) allow policies.
 type L7PolicyWriter interface {
-	Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string, index int) error
+	Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string) error
 	ListManaged(ctx context.Context, managedBy string) ([]client.Object, error)
 	IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool
 	Delete(ctx context.Context, obj client.Object) error
@@ -29,7 +42,7 @@ type L7PolicyWriter interface {
 // Writers that don't support this concept simply don't implement this interface.
 type MergeableL7PolicyWriter interface {
 	L7PolicyWriter
-	ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string, index int) error
+	ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error
 }
 
 // L4WriterRegistry maps GatewayClass controllerName to an L4PolicyWriter.

--- a/pkg/controllers/writers/interfaces.go
+++ b/pkg/controllers/writers/interfaces.go
@@ -45,6 +45,13 @@ type MergeableL7PolicyWriter interface {
 	ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error
 }
 
+// PathTranslator is an optional interface a writer can implement to control how HTTPRoute path
+// matches are translated into the enforcement-layer path strings passed to Apply.
+// Writers that don't implement this receive raw path values from match.Path.Value.
+type PathTranslator interface {
+	TranslatePaths(matches []gatewayApiv1.HTTPRouteMatch) []string
+}
+
 // L4WriterRegistry maps GatewayClass controllerName to an L4PolicyWriter.
 type L4WriterRegistry map[string]L4PolicyWriter
 

--- a/pkg/controllers/writers/interfaces.go
+++ b/pkg/controllers/writers/interfaces.go
@@ -1,0 +1,39 @@
+package writers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const IstioControllerName = "istio.io/gateway-controller"
+
+// L4PolicyWriter creates gateway-level (L4) allow policies.
+type L4PolicyWriter interface {
+	Apply(ctx context.Context, gateway *gatewayApiv1.Gateway, ips []string) error
+	Delete(ctx context.Context, gateway *gatewayApiv1.Gateway) error
+}
+
+// L7PolicyWriter creates route-level (L7) allow policies.
+type L7PolicyWriter interface {
+	Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string, index int) error
+	ListManaged(ctx context.Context, managedBy string) ([]client.Object, error)
+	IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool
+	Delete(ctx context.Context, obj client.Object) error
+}
+
+// MergeableL7PolicyWriter is an optional extension of L7PolicyWriter for writers that support
+// merging IPs and hosts from multiple HTTPRoutes into a single shared policy identified by a merge key.
+// Writers that don't support this concept simply don't implement this interface.
+type MergeableL7PolicyWriter interface {
+	L7PolicyWriter
+	ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string, index int) error
+}
+
+// L4WriterRegistry maps GatewayClass controllerName to an L4PolicyWriter.
+type L4WriterRegistry map[string]L4PolicyWriter
+
+// L7WriterRegistry maps GatewayClass controllerName to an L7PolicyWriter.
+type L7WriterRegistry map[string]L7PolicyWriter

--- a/pkg/controllers/writers/istio_l4.go
+++ b/pkg/controllers/writers/istio_l4.go
@@ -1,0 +1,68 @@
+package writers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+// IstioL4Writer creates/deletes Istio AuthorizationPolicies for Gateway-level (L4) allowlisting.
+type IstioL4Writer struct {
+	client client.Client
+}
+
+// NewIstioL4Writer returns a new IstioL4Writer using the provided client.
+func NewIstioL4Writer(c client.Client) *IstioL4Writer {
+	return &IstioL4Writer{client: c}
+}
+
+// Apply creates or updates an AuthorizationPolicy for the given Gateway and IPs.
+func (w *IstioL4Writer) Apply(ctx context.Context, gateway *gatewayApiv1.Gateway, ips []string) error {
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+		},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules: []*istioApiSecurityV1.Rule{
+				{
+					From: []*istioApiSecurityV1.Rule_From{
+						{
+							Source: &istioApiSecurityV1.Source{
+								RemoteIpBlocks: ips,
+							},
+						},
+					},
+				},
+			},
+			TargetRef: &istioApiTypeV1beta1.PolicyTargetReference{
+				Name:  gateway.Name,
+				Kind:  "Gateway",
+				Group: "gateway.networking.k8s.io",
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// Delete removes the AuthorizationPolicy associated with the given Gateway.
+func (w *IstioL4Writer) Delete(ctx context.Context, gateway *gatewayApiv1.Gateway) error {
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(w.client.Delete(ctx, policy))
+}

--- a/pkg/controllers/writers/istio_l4.go
+++ b/pkg/controllers/writers/istio_l4.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -23,8 +24,18 @@ func NewIstioL4Writer(c client.Client) *IstioL4Writer {
 	return &IstioL4Writer{client: c}
 }
 
+// RequiredPermissions returns the RBAC permissions needed by this writer.
+func (w *IstioL4Writer) RequiredPermissions() []Permission {
+	return []Permission{
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "get"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "create"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "update"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "delete"},
+	}
+}
+
 // Apply creates or updates an AuthorizationPolicy for the given Gateway and IPs.
-func (w *IstioL4Writer) Apply(ctx context.Context, gateway *gatewayApiv1.Gateway, ips []string) error {
+func (w *IstioL4Writer) Apply(ctx context.Context, scheme *runtime.Scheme, gateway *gatewayApiv1.Gateway, ips []string) error {
 	policy := &istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gateway.Name,
@@ -32,6 +43,9 @@ func (w *IstioL4Writer) Apply(ctx context.Context, gateway *gatewayApiv1.Gateway
 		},
 	}
 	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		if err := ctrl.SetControllerReference(gateway, policy, scheme); err != nil {
+			return err
+		}
 		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
 			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
 			Rules: []*istioApiSecurityV1.Rule{

--- a/pkg/controllers/writers/istio_l4_test.go
+++ b/pkg/controllers/writers/istio_l4_test.go
@@ -1,0 +1,95 @@
+package writers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+var istioL4Scheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = gatewayApiv1.Install(s)
+	_ = istiosecurityv1.AddToScheme(s)
+	return s
+}()
+
+func testL4Gateway(name, namespace string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+}
+
+func TestIstioL4Writer_Apply_CreatesAP(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	err := w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"})
+	assert.NoError(t, err)
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-gateway", ap.Spec.TargetRef.Name)
+}
+
+func TestIstioL4Writer_Apply_SetsOwnerReference(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	err := w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"})
+	assert.NoError(t, err)
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
+	assert.NoError(t, err)
+	assert.Len(t, ap.OwnerReferences, 1)
+	assert.Equal(t, "my-gateway", ap.OwnerReferences[0].Name)
+	assert.True(t, *ap.OwnerReferences[0].Controller)
+}
+
+func TestIstioL4Writer_Apply_UpdatesExistingAP(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	assert.NoError(t, w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"}))
+	assert.NoError(t, w.Apply(context.Background(), istioL4Scheme, gw, []string{"192.168.0.0/16"}))
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	assert.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap))
+	assert.Equal(t, []string{"192.168.0.0/16"}, ap.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+}
+
+func TestIstioL4Writer_Delete_RemovesAP(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	assert.NoError(t, w.Apply(context.Background(), istioL4Scheme, gw, []string{"10.0.0.0/8"}))
+	assert.NoError(t, w.Delete(context.Background(), gw))
+
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-gateway", Namespace: "mynamespace"}, ap)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "AP should be gone")
+}
+
+func TestIstioL4Writer_Delete_ToleratesNotFound(t *testing.T) {
+	gw := testL4Gateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL4Scheme).WithObjects(gw).Build()
+	w := NewIstioL4Writer(k8sClient)
+
+	assert.NoError(t, w.Delete(context.Background(), gw))
+}

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -3,10 +3,14 @@ package writers
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"regexp"
+	"sort"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -58,32 +62,119 @@ func (w *IstioL7Writer) applyLabels(policy *istiosecurityv1.AuthorizationPolicy,
 	policy.Labels[w.annotationPrefix+"/owner-name"] = LabelSafe(ownerName)
 }
 
-// policyName computes the AP name for a given route at the given index.
-// index is the position of this parentRef among Gateway parentRefs (0-based).
-// crossNamespace is true when the gateway is in a different namespace than the route.
-func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, index int) (name, namespace string, crossNamespace bool) {
+// pathSafe converts a URL path to a safe AP name suffix.
+// Encoding: escape "-" as "--", trim surrounding "/", replace remaining "/" with "-".
+// Returns empty string only for "/" (or equivalent all-slash paths).
+// Examples: /admin/users → admin-users, /admin-users → admin--users, /root → root, / → ""
+func pathSafe(path string) string {
+	escaped := strings.ReplaceAll(path, "-", "--")
+	escaped = strings.Trim(escaped, "/")
+	return strings.ReplaceAll(escaped, "/", "-")
+}
+
+// policyName computes the AP name and namespace for a given route+gateway+paths.
+// Format: {gateway.Name}-{route.Name} (same-namespace)
+//
+//	{gateway.Name}-{route.Namespace}-{route.Name} (cross-namespace, AP lives in gateway's namespace)
+//
+// When paths is non-empty, a path-safe suffix is appended so each HTTPRoute rule gets its own AP.
+func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, paths []string) (name, namespace string, crossNamespace bool) {
 	crossNamespace = gateway.Namespace != route.Namespace
 	namespace = route.Namespace
-	baseName := route.Name
+	baseName := gateway.Name + "-" + route.Name
 	if crossNamespace {
 		namespace = gateway.Namespace
-		baseName = route.Namespace + "-" + route.Name
+		baseName = gateway.Name + "-" + route.Namespace + "-" + route.Name
 	}
 	name = baseName
-	if index > 0 {
-		name = fmt.Sprintf("%s-%d", baseName, index)
+	if len(paths) == 1 {
+		// Single path: keep the human-readable suffix, no hash needed.
+		safe := pathSafe(paths[0])
+		if safe == "" {
+			safe = "-root"
+		}
+		name = fmt.Sprintf("%s-%s", baseName, safe)
+	} else if len(paths) > 1 {
+		// Multiple paths: first path (readable) + hash of the full sorted set.
+		// e.g. ["/api", "/health"] → "{base}-api-3d2a1f8c"
+		// The hash disambiguates sets sharing the same first path; the readable
+		// prefix lets humans quickly identify the rule without inspecting the AP spec.
+		sorted := make([]string, len(paths))
+		copy(sorted, paths)
+		sort.Strings(sorted)
+		h := fnv.New32a()
+		for _, p := range sorted {
+			_, _ = h.Write([]byte(p))
+		}
+		first := pathSafe(sorted[0])
+		if first == "" {
+			first = "-root"
+		}
+		name = fmt.Sprintf("%s-%s-%08x", baseName, first, h.Sum32())
 	}
+	name = truncateName(name)
 	return name, namespace, crossNamespace
 }
 
-// Apply creates or updates an AuthorizationPolicy for the given HTTPRoute parentRef at the given index.
-func (w *IstioL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string, index int) error {
-	apName, apNamespace, crossNamespace := policyName(route, gateway, index)
+// truncateName ensures a Kubernetes resource name stays within the 253-char limit.
+// Names that fit are returned unchanged. Names that overflow are truncated to 244 chars
+// and suffixed with "-{fnv32hex(fullName)}" (9 chars) to keep them collision-resistant.
+func truncateName(name string) string {
+	const maxLen = 253
+	const hashSuffixLen = 9 // "-" + 8 hex chars
+	if len(name) <= maxLen {
+		return name
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	return fmt.Sprintf("%s-%08x", name[:maxLen-hashSuffixLen], h.Sum32())
+}
+
+// policyNameSuffix returns the AP name suffix for a given path set, mirroring policyName.
+func policyNameSuffix(paths []string) string {
+	if len(paths) == 1 {
+		safe := pathSafe(paths[0])
+		if safe == "" {
+			safe = "-root"
+		}
+		return "-" + safe
+	}
+	if len(paths) > 1 {
+		sorted := make([]string, len(paths))
+		copy(sorted, paths)
+		sort.Strings(sorted)
+		h := fnv.New32a()
+		for _, p := range sorted {
+			_, _ = h.Write([]byte(p))
+		}
+		first := pathSafe(sorted[0])
+		if first == "" {
+			first = "-root"
+		}
+		return fmt.Sprintf("-%s-%08x", first, h.Sum32())
+	}
+	return ""
+}
+
+// RequiredPermissions returns the RBAC permissions needed by this writer.
+func (w *IstioL7Writer) RequiredPermissions() []Permission {
+	return []Permission{
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "get"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "create"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "update"},
+		{Group: "security.istio.io", Resource: "authorizationpolicies", Verb: "delete"},
+	}
+}
+
+// Apply creates or updates an AuthorizationPolicy for the given HTTPRoute+gateway+paths combination.
+// When paths is non-empty the AP name includes a path-safe suffix so each rule gets its own AP.
+func (w *IstioL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string) error {
+	apName, apNamespace, crossNamespace := policyName(route, gateway, paths)
 
 	policy := &istiosecurityv1.AuthorizationPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: apName, Namespace: apNamespace},
 	}
-	rules := buildAuthorizationRules(ips, hosts)
+	rules := buildAuthorizationRules(ips, hosts, paths)
 	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
 		if !crossNamespace {
 			if err := ctrl.SetControllerReference(route, policy, scheme); err != nil {
@@ -94,62 +185,6 @@ func (w *IstioL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route
 		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
 			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
 			Rules:  rules,
-			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
-			},
-		}
-		return nil
-	})
-	return err
-}
-
-// ApplyMerged creates or updates a merged AuthorizationPolicy for a merge group.
-// It aggregates IPs and hosts from all sibling HTTPRoutes internally.
-// Path support (granularity=path) is not yet implemented — paths are ignored for now.
-func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string, index int) error {
-	seenIPs := map[string]struct{}{}
-	seenHosts := map[string]struct{}{}
-	var mergedIPs, mergedHosts []string
-
-	for _, sibling := range siblings {
-		ips, err := w.cidrResolver.GetCidrsFromObject(ctx, sibling)
-		if err == w.cidrResolver.AnnotationNotFoundError() {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		for _, ip := range ips {
-			if _, seen := seenIPs[ip]; !seen {
-				seenIPs[ip] = struct{}{}
-				mergedIPs = append(mergedIPs, ip)
-			}
-		}
-		for _, h := range sibling.Spec.Hostnames {
-			host := string(h)
-			if _, seen := seenHosts[host]; !seen {
-				seenHosts[host] = struct{}{}
-				mergedHosts = append(mergedHosts, host)
-			}
-		}
-	}
-
-	if len(mergedIPs) == 0 {
-		return nil
-	}
-
-	apName := mergeKey
-	if index > 0 {
-		apName = fmt.Sprintf("%s-%d", mergeKey, index)
-	}
-	policy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: apName, Namespace: gateway.Namespace},
-	}
-	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
-		w.applyLabels(policy, "merged", mergeKey)
-		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-			Rules:  buildAuthorizationRules(mergedIPs, mergedHosts),
 			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
 				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
 			},
@@ -180,7 +215,7 @@ func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.H
 	ownerName := obj.GetLabels()[w.annotationPrefix+"/owner-name"]
 	mergeAnnotation := w.annotationPrefix + "/merge"
 
-	if ownerNS == "merged" {
+	if ownerNS == "MERGED" {
 		// Merge-mode AP: check if any route still has this merge key
 		for i := range allRoutes {
 			if allRoutes[i].Annotations[mergeAnnotation] == ownerName {
@@ -198,10 +233,9 @@ func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.H
 		}
 		// Route exists — check if it's in merge mode now
 		if r.Annotations[mergeAnnotation] != "" {
-			// Route switched to merge mode — old non-merge AP is orphaned
 			return true
 		}
-		// Check if the route still produces this AP
+		// Check if the route still produces this AP (exact or path-suffixed)
 		if routeProducesPolicy(r, obj.GetNamespace(), obj.GetName()) {
 			return false
 		}
@@ -217,39 +251,54 @@ func (w *IstioL7Writer) Delete(ctx context.Context, obj client.Object) error {
 	return client.IgnoreNotFound(w.client.Delete(ctx, obj))
 }
 
-// policyTargets computes the complete set of AuthorizationPolicies that the non-merge
-// reconcile path would produce for route: one per Gateway parentRef.
-// This mirrors the naming convention used in Apply.
+// policyTarget is a single (namespace, name) pair identifying an AuthorizationPolicy.
 type policyTarget struct {
 	namespace string
 	name      string
 }
 
+// policyTargetsForRoute returns the exact set of AP (namespace, name) pairs that the
+// non-merge reconcile path would produce for route — one per rule (with path suffixes),
+// plus the no-path base name for routes with no rules.
+// Used by IsOrphaned for exact matching — no prefix heuristics.
 func policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
 	var targets []policyTarget
-	refs := gatewayParentRefs(route)
-	for i, ref := range refs {
-		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != route.Namespace
+	for _, ref := range gatewayParentRefs(route) {
+		refNS := route.Namespace
+		if ref.Namespace != nil {
+			refNS = string(*ref.Namespace)
+		}
+		crossNamespace := refNS != route.Namespace
 		targetNamespace := route.Namespace
-		baseName := route.Name
+		gatewayName := string(ref.Name)
+		baseName := gatewayName + "-" + route.Name
 		if crossNamespace {
-			targetNamespace = string(*ref.Namespace)
-			baseName = route.Namespace + "-" + route.Name
+			targetNamespace = refNS
+			baseName = gatewayName + "-" + route.Namespace + "-" + route.Name
 		}
-		name := baseName
-		if i > 0 {
-			name = fmt.Sprintf("%s-%d", baseName, i)
+
+		if len(route.Spec.Rules) == 0 {
+			targets = append(targets, policyTarget{namespace: targetNamespace, name: baseName})
+			continue
 		}
-		targets = append(targets, policyTarget{
-			namespace: targetNamespace,
-			name:      name,
-		})
+		for _, rule := range route.Spec.Rules {
+			var paths []string
+			for _, match := range rule.Matches {
+				if match.Path != nil && match.Path.Value != nil {
+					paths = append(paths, *match.Path.Value)
+				}
+			}
+			targets = append(targets, policyTarget{
+				namespace: targetNamespace,
+				name:      truncateName(baseName + policyNameSuffix(paths)),
+			})
+		}
 	}
 	return targets
 }
 
 // routeProducesPolicy reports whether the non-merge reconcile path for route would generate
-// an AuthorizationPolicy at the given {namespace, name}.
+// an AuthorizationPolicy at the given {namespace, name}. Uses exact matching only.
 func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
 	for _, pt := range policyTargetsForRoute(route) {
 		if pt.namespace == policyNamespace && pt.name == policyName {
@@ -275,7 +324,8 @@ func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentR
 }
 
 // buildAuthorizationRules builds the Istio rules for an AuthorizationPolicy.
-func buildAuthorizationRules(allowedIPs, hostnames []string) []*istioApiSecurityV1.Rule {
+// When paths is non-empty, Operation.Paths is set to restrict to those paths.
+func buildAuthorizationRules(allowedIPs, hostnames, paths []string) []*istioApiSecurityV1.Rule {
 	rules := []*istioApiSecurityV1.Rule{
 		{
 			From: []*istioApiSecurityV1.Rule_From{
@@ -283,10 +333,22 @@ func buildAuthorizationRules(allowedIPs, hostnames []string) []*istioApiSecurity
 			},
 		},
 	}
-	if len(hostnames) > 0 {
+	if len(hostnames) > 0 || len(paths) > 0 {
+		op := &istioApiSecurityV1.Operation{}
+		if len(hostnames) > 0 {
+			op.Hosts = hostnames
+		}
+		if len(paths) > 0 {
+			op.Paths = paths
+		}
 		rules[0].To = []*istioApiSecurityV1.Rule_To{
-			{Operation: &istioApiSecurityV1.Operation{Hosts: hostnames}},
+			{Operation: op},
 		}
 	}
 	return rules
+}
+
+// dedupSorted returns a sorted, deduplicated copy of the input slice.
+func dedupSorted(items []string) []string {
+	return sets.List(sets.New[string](items...))
 }

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -19,6 +19,7 @@ import (
 	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
 
@@ -236,7 +237,7 @@ func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.H
 			return true
 		}
 		// Check if the route still produces this AP (exact or path-suffixed)
-		if routeProducesPolicy(r, obj.GetNamespace(), obj.GetName()) {
+		if w.routeProducesPolicy(r, obj.GetNamespace(), obj.GetName()) {
 			return false
 		}
 		return true
@@ -258,12 +259,13 @@ type policyTarget struct {
 }
 
 // policyTargetsForRoute returns the exact set of AP (namespace, name) pairs that the
-// non-merge reconcile path would produce for route — one per rule (with path suffixes),
-// plus the no-path base name for routes with no rules.
+// non-merge reconcile path would produce for route — mirrors the Apply call-sites exactly.
 // Used by IsOrphaned for exact matching — no prefix heuristics.
-func policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
+func (w *IstioL7Writer) policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
+	granularity := route.Annotations[w.annotationPrefix+"/granularity"]
+
 	var targets []policyTarget
-	for _, ref := range gatewayParentRefs(route) {
+	for _, ref := range gateway.GatewayParentRefs(route) {
 		refNS := route.Namespace
 		if ref.Namespace != nil {
 			refNS = string(*ref.Namespace)
@@ -277,17 +279,19 @@ func policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
 			baseName = gatewayName + "-" + route.Namespace + "-" + route.Name
 		}
 
+		// granularity=host: one AP with base name, no path suffix.
+		if granularity == "host" {
+			targets = append(targets, policyTarget{namespace: targetNamespace, name: baseName})
+			continue
+		}
+
+		// granularity=rule (default): one AP per rule with path suffix.
 		if len(route.Spec.Rules) == 0 {
 			targets = append(targets, policyTarget{namespace: targetNamespace, name: baseName})
 			continue
 		}
 		for _, rule := range route.Spec.Rules {
-			var paths []string
-			for _, match := range rule.Matches {
-				if match.Path != nil && match.Path.Value != nil {
-					paths = append(paths, *match.Path.Value)
-				}
-			}
+			paths := w.TranslatePaths(rule.Matches)
 			targets = append(targets, policyTarget{
 				namespace: targetNamespace,
 				name:      truncateName(baseName + policyNameSuffix(paths)),
@@ -299,28 +303,13 @@ func policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
 
 // routeProducesPolicy reports whether the non-merge reconcile path for route would generate
 // an AuthorizationPolicy at the given {namespace, name}. Uses exact matching only.
-func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
-	for _, pt := range policyTargetsForRoute(route) {
+func (w *IstioL7Writer) routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
+	for _, pt := range w.policyTargetsForRoute(route) {
 		if pt.namespace == policyNamespace && pt.name == policyName {
 			return true
 		}
 	}
 	return false
-}
-
-// gatewayParentRefs returns all parentRefs that target a Gateway.
-func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
-	var refs []gatewayApiv1.ParentReference
-	for _, ref := range httproute.Spec.ParentRefs {
-		if ref.Kind != nil && *ref.Kind != "Gateway" {
-			continue
-		}
-		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
-			continue
-		}
-		refs = append(refs, ref)
-	}
-	return refs
 }
 
 // buildAuthorizationRules builds the Istio rules for an AuthorizationPolicy.
@@ -346,6 +335,36 @@ func buildAuthorizationRules(allowedIPs, hostnames, paths []string) []*istioApiS
 		}
 	}
 	return rules
+}
+
+// TranslatePaths implements PathTranslator for Istio AuthorizationPolicy path semantics.
+// PathPrefix /chaos → ["/chaos", "/chaos/*"] (exact + glob, covers /chaos and all sub-paths)
+// Exact /chaos     → ["/chaos"]              (passed through unchanged)
+// RegularExpression → skipped                (not supported by Istio AuthorizationPolicy)
+func (w *IstioL7Writer) TranslatePaths(matches []gatewayApiv1.HTTPRouteMatch) []string {
+	var paths []string
+	for _, match := range matches {
+		if match.Path == nil || match.Path.Value == nil {
+			continue
+		}
+		v := *match.Path.Value
+		t := gatewayApiv1.PathMatchPathPrefix // default per Gateway API spec
+		if match.Path.Type != nil {
+			t = *match.Path.Type
+		}
+		switch t {
+		case gatewayApiv1.PathMatchPathPrefix:
+			if v == "/" {
+				paths = append(paths, "/*")
+			} else {
+				paths = append(paths, v, v+"/*")
+			}
+		case gatewayApiv1.PathMatchExact:
+			paths = append(paths, v)
+		// RegularExpression: not supported by Istio AP — skip
+		}
+	}
+	return paths
 }
 
 // dedupSorted returns a sorted, deduplicated copy of the input slice.

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -1,0 +1,292 @@
+package writers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+// invalidLabelValue matches characters not allowed in k8s label values.
+var invalidLabelValue = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
+
+// LabelSafe sanitizes a string for use as a Kubernetes label value.
+func LabelSafe(s string) string {
+	v := invalidLabelValue.ReplaceAllString(s, "_")
+	if len(v) > 63 {
+		v = v[:63]
+	}
+	return v
+}
+
+// IstioL7Writer creates/deletes Istio AuthorizationPolicies for HTTPRoute-level (L7) allowlisting.
+type IstioL7Writer struct {
+	client           client.Client
+	managedBy        string
+	annotationPrefix string
+	cidrResolver     resolvers.CidrResolver
+}
+
+// NewIstioL7Writer returns a new IstioL7Writer.
+func NewIstioL7Writer(c client.Client, managedBy string, cidrResolver resolvers.CidrResolver) *IstioL7Writer {
+	return &IstioL7Writer{
+		client:           c,
+		managedBy:        managedBy,
+		annotationPrefix: cidrResolver.AnnotationPrefix,
+		cidrResolver:     cidrResolver,
+	}
+}
+
+// applyLabels sets standard managed-by and owner labels on the policy.
+func (w *IstioL7Writer) applyLabels(policy *istiosecurityv1.AuthorizationPolicy, ownerNamespace, ownerName string) {
+	if policy.Labels == nil {
+		policy.Labels = map[string]string{}
+	}
+	policy.Labels["app.kubernetes.io/managed-by"] = w.managedBy
+	policy.Labels[w.annotationPrefix+"/owner-namespace"] = LabelSafe(ownerNamespace)
+	policy.Labels[w.annotationPrefix+"/owner-name"] = LabelSafe(ownerName)
+}
+
+// policyName computes the AP name for a given route at the given index.
+// index is the position of this parentRef among Gateway parentRefs (0-based).
+// crossNamespace is true when the gateway is in a different namespace than the route.
+func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, index int) (name, namespace string, crossNamespace bool) {
+	crossNamespace = gateway.Namespace != route.Namespace
+	namespace = route.Namespace
+	baseName := route.Name
+	if crossNamespace {
+		namespace = gateway.Namespace
+		baseName = route.Namespace + "-" + route.Name
+	}
+	name = baseName
+	if index > 0 {
+		name = fmt.Sprintf("%s-%d", baseName, index)
+	}
+	return name, namespace, crossNamespace
+}
+
+// Apply creates or updates an AuthorizationPolicy for the given HTTPRoute parentRef at the given index.
+func (w *IstioL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, ips, hosts, paths []string, index int) error {
+	apName, apNamespace, crossNamespace := policyName(route, gateway, index)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: apName, Namespace: apNamespace},
+	}
+	rules := buildAuthorizationRules(ips, hosts)
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		if !crossNamespace {
+			if err := ctrl.SetControllerReference(route, policy, scheme); err != nil {
+				return err
+			}
+		}
+		w.applyLabels(policy, route.Namespace, route.Name)
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules:  rules,
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// ApplyMerged creates or updates a merged AuthorizationPolicy for a merge group.
+// It aggregates IPs and hosts from all sibling HTTPRoutes internally.
+// Path support (granularity=path) is not yet implemented — paths are ignored for now.
+func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string, index int) error {
+	seenIPs := map[string]struct{}{}
+	seenHosts := map[string]struct{}{}
+	var mergedIPs, mergedHosts []string
+
+	for _, sibling := range siblings {
+		ips, err := w.cidrResolver.GetCidrsFromObject(ctx, sibling)
+		if err == w.cidrResolver.AnnotationNotFoundError() {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, ip := range ips {
+			if _, seen := seenIPs[ip]; !seen {
+				seenIPs[ip] = struct{}{}
+				mergedIPs = append(mergedIPs, ip)
+			}
+		}
+		for _, h := range sibling.Spec.Hostnames {
+			host := string(h)
+			if _, seen := seenHosts[host]; !seen {
+				seenHosts[host] = struct{}{}
+				mergedHosts = append(mergedHosts, host)
+			}
+		}
+	}
+
+	if len(mergedIPs) == 0 {
+		return nil
+	}
+
+	apName := mergeKey
+	if index > 0 {
+		apName = fmt.Sprintf("%s-%d", mergeKey, index)
+	}
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: apName, Namespace: gateway.Namespace},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		w.applyLabels(policy, "merged", mergeKey)
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules:  buildAuthorizationRules(mergedIPs, mergedHosts),
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// ListManaged returns all AuthorizationPolicies managed by this controller (identified by managedBy label).
+func (w *IstioL7Writer) ListManaged(ctx context.Context, managedBy string) ([]client.Object, error) {
+	list := &istiosecurityv1.AuthorizationPolicyList{}
+	if err := w.client.List(ctx, list, client.MatchingLabels{
+		"app.kubernetes.io/managed-by": managedBy,
+	}); err != nil {
+		return nil, err
+	}
+	result := make([]client.Object, len(list.Items))
+	for i, item := range list.Items {
+		result[i] = item
+	}
+	return result, nil
+}
+
+// IsOrphaned reports whether the given AP no longer has a valid owner HTTPRoute.
+func (w *IstioL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool {
+	ownerNS := obj.GetLabels()[w.annotationPrefix+"/owner-namespace"]
+	ownerName := obj.GetLabels()[w.annotationPrefix+"/owner-name"]
+	mergeAnnotation := w.annotationPrefix + "/merge"
+
+	if ownerNS == "merged" {
+		// Merge-mode AP: check if any route still has this merge key
+		for i := range allRoutes {
+			if allRoutes[i].Annotations[mergeAnnotation] == ownerName {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Normal AP: check if owner route still exists and still produces this AP
+	for i := range allRoutes {
+		r := &allRoutes[i]
+		if r.Namespace != ownerNS || r.Name != ownerName {
+			continue
+		}
+		// Route exists — check if it's in merge mode now
+		if r.Annotations[mergeAnnotation] != "" {
+			// Route switched to merge mode — old non-merge AP is orphaned
+			return true
+		}
+		// Check if the route still produces this AP
+		if routeProducesPolicy(r, obj.GetNamespace(), obj.GetName()) {
+			return false
+		}
+		return true
+	}
+
+	// Route not found in list — it's gone
+	return true
+}
+
+// Delete removes the given object from the cluster.
+func (w *IstioL7Writer) Delete(ctx context.Context, obj client.Object) error {
+	return client.IgnoreNotFound(w.client.Delete(ctx, obj))
+}
+
+// policyTargets computes the complete set of AuthorizationPolicies that the non-merge
+// reconcile path would produce for route: one per Gateway parentRef.
+// This mirrors the naming convention used in Apply.
+type policyTarget struct {
+	namespace string
+	name      string
+}
+
+func policyTargetsForRoute(route *gatewayApiv1.HTTPRoute) []policyTarget {
+	var targets []policyTarget
+	refs := gatewayParentRefs(route)
+	for i, ref := range refs {
+		crossNamespace := ref.Namespace != nil && string(*ref.Namespace) != route.Namespace
+		targetNamespace := route.Namespace
+		baseName := route.Name
+		if crossNamespace {
+			targetNamespace = string(*ref.Namespace)
+			baseName = route.Namespace + "-" + route.Name
+		}
+		name := baseName
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d", baseName, i)
+		}
+		targets = append(targets, policyTarget{
+			namespace: targetNamespace,
+			name:      name,
+		})
+	}
+	return targets
+}
+
+// routeProducesPolicy reports whether the non-merge reconcile path for route would generate
+// an AuthorizationPolicy at the given {namespace, name}.
+func routeProducesPolicy(route *gatewayApiv1.HTTPRoute, policyNamespace, policyName string) bool {
+	for _, pt := range policyTargetsForRoute(route) {
+		if pt.namespace == policyNamespace && pt.name == policyName {
+			return true
+		}
+	}
+	return false
+}
+
+// gatewayParentRefs returns all parentRefs that target a Gateway.
+func gatewayParentRefs(httproute *gatewayApiv1.HTTPRoute) []gatewayApiv1.ParentReference {
+	var refs []gatewayApiv1.ParentReference
+	for _, ref := range httproute.Spec.ParentRefs {
+		if ref.Kind != nil && *ref.Kind != "Gateway" {
+			continue
+		}
+		if ref.Group != nil && *ref.Group != "gateway.networking.k8s.io" {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// buildAuthorizationRules builds the Istio rules for an AuthorizationPolicy.
+func buildAuthorizationRules(allowedIPs, hostnames []string) []*istioApiSecurityV1.Rule {
+	rules := []*istioApiSecurityV1.Rule{
+		{
+			From: []*istioApiSecurityV1.Rule_From{
+				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: allowedIPs}},
+			},
+		},
+	}
+	if len(hostnames) > 0 {
+		rules[0].To = []*istioApiSecurityV1.Rule_To{
+			{Operation: &istioApiSecurityV1.Operation{Hosts: hostnames}},
+		}
+	}
+	return rules
+}

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -1,0 +1,220 @@
+package writers
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istioApiSecurityV1 "istio.io/api/security/v1"
+	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+// mergedTuple is a single (cidr-set, host-set, paths) entry emitted per rule during ApplyMerged grouping.
+type mergedTuple struct {
+	cidrKey string   // sorted joined CIDRs — group key
+	hostKey string   // sorted joined hosts — group key
+	cidrs   []string // original CIDRs (same order as cidrKey was built from)
+	hosts   []string // original hosts (same order as hostKey was built from)
+	paths   []string // paths for this rule (nil means host-only granularity)
+}
+
+// ApplyMerged creates or updates a merged AuthorizationPolicy for a merge group.
+//
+// Security model: routes with different CIDR sets must NOT share a `from` block,
+// otherwise a CIDR allowed on one host would implicitly gain access to another host.
+//
+// Algorithm (two-level grouping):
+//  1. For each sibling route, collect per-rule tuples: (sorted_cidrs, sorted_hosts, paths).
+//     When granularity=host the route contributes one tuple (no paths); otherwise one per rule.
+//  2. Group tuples by sorted_cidrs → one Istio Rule per unique CIDR set (one `from` block).
+//  3. Within each CIDR group, group by sorted_hosts → one `to` Operation per unique host set.
+//  4. Collect all paths from matching tuples into that Operation.
+//  5. Compact `to` operations sharing the same path set into one (merging their host lists).
+func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error {
+	granularityAnnotation := w.annotationPrefix + "/granularity"
+
+	var tuples []mergedTuple
+	for _, sibling := range siblings {
+		ips, err := w.cidrResolver.GetCidrsFromObject(ctx, sibling)
+		if err == w.cidrResolver.AnnotationNotFoundError() {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if len(ips) == 0 {
+			continue
+		}
+
+		sortedIPs := make([]string, len(ips))
+		copy(sortedIPs, ips)
+		sort.Strings(sortedIPs)
+		cidrKey := strings.Join(sortedIPs, ",")
+
+		var hosts []string
+		for _, h := range sibling.Spec.Hostnames {
+			hosts = append(hosts, string(h))
+		}
+		sort.Strings(hosts)
+		hostKey := strings.Join(hosts, ",")
+
+		granularity := sibling.Annotations[granularityAnnotation]
+		if granularity == "host" {
+			tuples = append(tuples, mergedTuple{
+				cidrKey: cidrKey, hostKey: hostKey,
+				cidrs: sortedIPs, hosts: hosts,
+				paths: nil,
+			})
+			continue
+		}
+
+		// granularity=rule (default): one tuple per HTTPRoute rule.
+		if len(sibling.Spec.Rules) == 0 {
+			tuples = append(tuples, mergedTuple{
+				cidrKey: cidrKey, hostKey: hostKey,
+				cidrs: sortedIPs, hosts: hosts,
+				paths: nil,
+			})
+			continue
+		}
+		for _, rule := range sibling.Spec.Rules {
+			var paths []string
+			for _, match := range rule.Matches {
+				if match.Path != nil && match.Path.Value != nil {
+					paths = append(paths, *match.Path.Value)
+				}
+			}
+			sort.Strings(paths)
+			tuples = append(tuples, mergedTuple{
+				cidrKey: cidrKey, hostKey: hostKey,
+				cidrs: sortedIPs, hosts: hosts,
+				paths: paths,
+			})
+		}
+	}
+
+	if len(tuples) == 0 {
+		return nil
+	}
+
+	// Group by cidrKey preserving first-seen order.
+	type hostPathGroup struct {
+		paths        []string
+		unrestricted bool // true if any route used granularity=host — overrides all path restrictions
+	}
+	type cidrGroup struct {
+		cidrs    []string
+		hostKeys []string
+		byHost   map[string]*hostPathGroup
+	}
+	cidrKeys := []string{}
+	byCIDR := map[string]*cidrGroup{}
+
+	for _, t := range tuples {
+		cg, exists := byCIDR[t.cidrKey]
+		if !exists {
+			cg = &cidrGroup{cidrs: t.cidrs, byHost: map[string]*hostPathGroup{}}
+			byCIDR[t.cidrKey] = cg
+			cidrKeys = append(cidrKeys, t.cidrKey)
+		}
+		hg, exists := cg.byHost[t.hostKey]
+		if !exists {
+			hg = &hostPathGroup{}
+			cg.byHost[t.hostKey] = hg
+			cg.hostKeys = append(cg.hostKeys, t.hostKey)
+		}
+		if t.paths == nil {
+			hg.unrestricted = true
+		} else {
+			hg.paths = append(hg.paths, t.paths...)
+		}
+	}
+
+	// Build Istio rules: one Rule per unique CIDR set.
+	var rules []*istioApiSecurityV1.Rule
+	for _, ck := range cidrKeys {
+		cg := byCIDR[ck]
+		rule := &istioApiSecurityV1.Rule{
+			From: []*istioApiSecurityV1.Rule_From{
+				{Source: &istioApiSecurityV1.Source{RemoteIpBlocks: cg.cidrs}},
+			},
+		}
+		for _, hk := range cg.hostKeys {
+			hg := cg.byHost[hk]
+			var hosts []string
+			if hk != "" {
+				hosts = strings.Split(hk, ",")
+			}
+			op := &istioApiSecurityV1.Operation{}
+			if len(hosts) > 0 {
+				op.Hosts = hosts
+			}
+			if !hg.unrestricted && len(hg.paths) > 0 {
+				op.Paths = dedupSorted(hg.paths)
+			}
+			if op.Hosts != nil || op.Paths != nil {
+				rule.To = append(rule.To, &istioApiSecurityV1.Rule_To{Operation: op})
+			}
+		}
+		rule.To = mergeTosByPaths(rule.To)
+		rules = append(rules, rule)
+	}
+
+	policy := &istiosecurityv1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: mergeKey, Namespace: gateway.Namespace},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+		w.applyLabels(policy, "MERGED", mergeKey)
+		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+			Rules:  rules,
+			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// mergeTosByPaths compacts `to` operations sharing the same path set into one, merging their host lists.
+func mergeTosByPaths(tos []*istioApiSecurityV1.Rule_To) []*istioApiSecurityV1.Rule_To {
+	type group struct {
+		hosts []string
+	}
+	keys := []string{}
+	byPathKey := map[string]*group{}
+
+	for _, to := range tos {
+		if to.Operation == nil {
+			continue
+		}
+		pathKey := strings.Join(to.Operation.Paths, ",")
+		g, exists := byPathKey[pathKey]
+		if !exists {
+			g = &group{}
+			byPathKey[pathKey] = g
+			keys = append(keys, pathKey)
+		}
+		g.hosts = append(g.hosts, to.Operation.Hosts...)
+	}
+
+	merged := make([]*istioApiSecurityV1.Rule_To, 0, len(keys))
+	for _, pathKey := range keys {
+		g := byPathKey[pathKey]
+		op := &istioApiSecurityV1.Operation{}
+		if len(g.hosts) > 0 {
+			op.Hosts = dedupSorted(g.hosts)
+		}
+		if pathKey != "" {
+			op.Paths = strings.Split(pathKey, ",")
+		}
+		merged = append(merged, &istioApiSecurityV1.Rule_To{Operation: op})
+	}
+	return merged
+}

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -83,12 +83,7 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 			continue
 		}
 		for _, rule := range sibling.Spec.Rules {
-			var paths []string
-			for _, match := range rule.Matches {
-				if match.Path != nil && match.Path.Value != nil {
-					paths = append(paths, *match.Path.Value)
-				}
-			}
+			paths := w.TranslatePaths(rule.Matches)
 			sort.Strings(paths)
 			tuples = append(tuples, mergedTuple{
 				cidrKey: cidrKey, hostKey: hostKey,

--- a/pkg/controllers/writers/istio_l7_merge_test.go
+++ b/pkg/controllers/writers/istio_l7_merge_test.go
@@ -133,7 +133,7 @@ func TestApplyMerged_SameCIDRSameHost(t *testing.T) {
 
 	assert.Len(t, policy.Spec.Rules, 1)
 	assert.Len(t, policy.Spec.Rules[0].To, 1)
-	assert.ElementsMatch(t, []string{"/api", "/health"}, policy.Spec.Rules[0].To[0].Operation.Paths)
+	assert.ElementsMatch(t, []string{"/api", "/api/*", "/health", "/health/*"}, policy.Spec.Rules[0].To[0].Operation.Paths)
 }
 
 // TestApplyMerged_GranularityHost verifies that granularity=host produces no paths in the merged AP.
@@ -195,7 +195,7 @@ func TestApplyMerged_SamePathsDifferentHosts(t *testing.T) {
 	require.Len(t, policy.Spec.Rules, 1, "same CIDR set must produce one Rule")
 	require.Len(t, policy.Spec.Rules[0].To, 1, "same path set must be compacted into one To operation")
 	assert.ElementsMatch(t, []string{"host-a.example.com", "host-b.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
-	assert.Equal(t, []string{"/"}, policy.Spec.Rules[0].To[0].Operation.Paths)
+	assert.Equal(t, []string{"/*"}, policy.Spec.Rules[0].To[0].Operation.Paths)
 }
 
 // TestApplyMerged_MixedGranularity verifies that when one route uses granularity=host and another
@@ -277,5 +277,5 @@ func TestApplyMerged_DeduplicatesPaths(t *testing.T) {
 
 	assert.Len(t, policy.Spec.Rules, 1)
 	assert.Len(t, policy.Spec.Rules[0].To, 1)
-	assert.Equal(t, []string{"/api"}, policy.Spec.Rules[0].To[0].Operation.Paths, "duplicate path must appear only once")
+	assert.ElementsMatch(t, []string{"/api", "/api/*"}, policy.Spec.Rules[0].To[0].Operation.Paths, "duplicate paths must appear only once after expansion")
 }

--- a/pkg/controllers/writers/istio_l7_merge_test.go
+++ b/pkg/controllers/writers/istio_l7_merge_test.go
@@ -1,0 +1,281 @@
+package writers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+)
+
+// allPolicyHosts collects every host across all rules and to-blocks of a policy.
+func allPolicyHosts(p *istiosecurityv1.AuthorizationPolicy) []string {
+	var hosts []string
+	for _, rule := range p.Spec.Rules {
+		for _, to := range rule.To {
+			if to.Operation != nil {
+				hosts = append(hosts, to.Operation.Hosts...)
+			}
+		}
+	}
+	return hosts
+}
+
+// allPolicyCIDRs collects every CIDR across all rules of a policy.
+func allPolicyCIDRs(p *istiosecurityv1.AuthorizationPolicy) []string {
+	var cidrs []string
+	for _, rule := range p.Spec.Rules {
+		for _, from := range rule.From {
+			if from.Source != nil {
+				cidrs = append(cidrs, from.Source.RemoteIpBlocks...)
+			}
+		}
+	}
+	return cidrs
+}
+
+// TestApplyMerged_SameCIDRSet verifies that two routes sharing the same CIDR set and no paths
+// are compacted into a single Rule with one `to` containing both hosts.
+func TestApplyMerged_SameCIDRSet(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	route0 := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route0.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route1 := testRoute("svc-b", "ns-b", "svc-b.example.com")
+	route1.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, route0, route1, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route0, route1}, "shared-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "shared-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 1, "same CIDR set must produce exactly one Rule")
+	assert.Equal(t, []string{"1.2.3.4/32"}, policy.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+	assert.Len(t, policy.Spec.Rules[0].To, 1, "same path set must be compacted into one To operation")
+	assert.ElementsMatch(t, []string{"svc-a.example.com", "svc-b.example.com"}, allPolicyHosts(policy))
+}
+
+// TestApplyMerged_DifferentCIDRSets verifies that routes with different CIDR sets each
+// produce their own Rule — the security boundary between CIDR sets must not be crossed.
+func TestApplyMerged_DifferentCIDRSets(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "5.6.7.8/32")
+	route0 := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route0.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route1 := testRoute("svc-b", "ns-b", "svc-b.example.com")
+	route1.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, route0, route1, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route0, route1}, "multi-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "multi-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 2, "distinct CIDR sets must each produce their own Rule")
+	assert.ElementsMatch(t, []string{"1.2.3.4/32", "5.6.7.8/32"}, allPolicyCIDRs(policy))
+	assert.ElementsMatch(t, []string{"svc-a.example.com", "svc-b.example.com"}, allPolicyHosts(policy))
+
+	for _, rule := range policy.Spec.Rules {
+		cidr := rule.From[0].Source.RemoteIpBlocks[0]
+		host := rule.To[0].Operation.Hosts[0]
+		switch cidr {
+		case "1.2.3.4/32":
+			assert.Equal(t, "svc-a.example.com", host)
+		case "5.6.7.8/32":
+			assert.Equal(t, "svc-b.example.com", host)
+		default:
+			t.Fatalf("unexpected CIDR in rule: %s", cidr)
+		}
+	}
+}
+
+// TestApplyMerged_SameCIDRSameHost collapses paths from multiple rules into one `to`.
+func TestApplyMerged_SameCIDRSameHost(t *testing.T) {
+	cidr := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	pathValue1 := "/api"
+	pathValue2 := "/health"
+	route := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue1}}}},
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue2}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr, route, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 1)
+	assert.Len(t, policy.Spec.Rules[0].To, 1)
+	assert.ElementsMatch(t, []string{"/api", "/health"}, policy.Spec.Rules[0].To[0].Operation.Paths)
+}
+
+// TestApplyMerged_GranularityHost verifies that granularity=host produces no paths in the merged AP.
+func TestApplyMerged_GranularityHost(t *testing.T) {
+	cidr := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	pathValue := "/api"
+	route := testRoute("svc-a", "ns-a", "svc-a.example.com")
+	route.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	route.Annotations["ipam.adevinta.com/granularity"] = "host"
+	route.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr, route, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"svc-a.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Nil(t, policy.Spec.Rules[0].To[0].Operation.Paths, "granularity=host must produce no path restriction")
+}
+
+// TestApplyMerged_SamePathsDifferentHosts verifies that two routes with the same CIDR set and
+// the same path set but different hosts are compacted into a single `to` operation with both hosts.
+func TestApplyMerged_SamePathsDifferentHosts(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	pathValue := "/"
+	routeA := testRoute("svc-a", "ns-a", "host-a.example.com")
+	routeA.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeA.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	routeB := testRoute("svc-b", "ns-b", "host-b.example.com")
+	routeB.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeB.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, routeA, routeB, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{routeA, routeB}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	require.Len(t, policy.Spec.Rules, 1, "same CIDR set must produce one Rule")
+	require.Len(t, policy.Spec.Rules[0].To, 1, "same path set must be compacted into one To operation")
+	assert.ElementsMatch(t, []string{"host-a.example.com", "host-b.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Equal(t, []string{"/"}, policy.Spec.Rules[0].To[0].Operation.Paths)
+}
+
+// TestApplyMerged_MixedGranularity verifies that when one route uses granularity=host and another
+// uses granularity=rule within the same host group, the merged AP must have no path restriction —
+// the host-granularity route wins and overrides any path restriction from the rule-granularity route.
+func TestApplyMerged_MixedGranularity(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	pathValue := "/api"
+	routeHost := testRoute("svc-host", "ns-a", "shared.example.com")
+	routeHost.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeHost.Annotations["ipam.adevinta.com/granularity"] = "host"
+	routeRule := testRoute("svc-rule", "ns-b", "shared.example.com")
+	routeRule.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+	routeRule.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+		{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, routeHost, routeRule, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{routeHost, routeRule}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	require.Len(t, policy.Spec.Rules, 1)
+	require.Len(t, policy.Spec.Rules[0].To, 1)
+	assert.Equal(t, []string{"shared.example.com"}, policy.Spec.Rules[0].To[0].Operation.Hosts)
+	assert.Nil(t, policy.Spec.Rules[0].To[0].Operation.Paths, "host-granularity route must suppress path restriction for the entire host group")
+}
+
+// TestApplyMerged_EmptySkipped verifies that routes without a CIDR annotation are skipped.
+func TestApplyMerged_EmptySkipped(t *testing.T) {
+	route := testRoute("no-cidr", "ns-a", "no-cidr.example.com")
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(route, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{route}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "no policy should be created when no CIDRs are available")
+}
+
+// TestApplyMerged_DeduplicatesPaths verifies that duplicate paths within the same host group are collapsed.
+func TestApplyMerged_DeduplicatesPaths(t *testing.T) {
+	cidr0 := testCIDRs("allowlist", "ns-a", "1.2.3.4/32")
+	cidr1 := testCIDRs("allowlist", "ns-b", "1.2.3.4/32")
+	pathValue := "/api"
+	makeRoute := func(name, ns string) *gatewayApiv1.HTTPRoute {
+		r := testRoute(name, ns, "shared.example.com")
+		r.Annotations["ipam.adevinta.com/allowlist-group"] = "allowlist"
+		r.Spec.Rules = []gatewayApiv1.HTTPRouteRule{
+			{Matches: []gatewayApiv1.HTTPRouteMatch{{Path: &gatewayApiv1.HTTPPathMatch{Value: &pathValue}}}},
+		}
+		return r
+	}
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(cidr0, cidr1, makeRoute("svc-a", "ns-a"), makeRoute("svc-b", "ns-b"), gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{makeRoute("svc-a", "ns-a"), makeRoute("svc-b", "ns-b")}, "my-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	assert.Len(t, policy.Spec.Rules, 1)
+	assert.Len(t, policy.Spec.Rules[0].To, 1)
+	assert.Equal(t, []string{"/api"}, policy.Spec.Rules[0].To[0].Operation.Paths, "duplicate path must appear only once")
+}

--- a/pkg/controllers/writers/istio_l7_test.go
+++ b/pkg/controllers/writers/istio_l7_test.go
@@ -1,0 +1,155 @@
+package writers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+var istioL7Scheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = gatewayApiv1.Install(s)
+	_ = istiosecurityv1.AddToScheme(s)
+	_ = ipamv1alpha1.AddToScheme(s)
+	return s
+}()
+
+func newIstioL7Writer(c client.Client) *IstioL7Writer {
+	resolver := resolvers.CidrResolver{Client: c, AnnotationPrefix: resolvers.DefaultPrefix}
+	return NewIstioL7Writer(c, "ingress-allowlisting-controller", resolver)
+}
+
+func testGateway(name, namespace string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+}
+
+func testRoute(name, namespace string, hostnames ...string) *gatewayApiv1.HTTPRoute {
+	r := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+	}
+	for _, h := range hostnames {
+		r.Spec.Hostnames = append(r.Spec.Hostnames, gatewayApiv1.Hostname(h))
+	}
+	return r
+}
+
+func testCIDRs(name, namespace string, cidrs ...string) *ipamv1alpha1.CIDRs {
+	return &ipamv1alpha1.CIDRs{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: cidrs},
+	}
+}
+
+// TestPolicyNameMultiPathNoCollision verifies the AP naming scheme for multi-path rules.
+// Single path: human-readable pathSafe suffix (unchanged from before).
+// Multiple paths: FNV-32a hex hash of the sorted set — valid K8s name chars, order-independent.
+func TestPolicyNameMultiPathNoCollision(t *testing.T) {
+	gw := &gatewayApiv1.Gateway{}
+	gw.Name = "gw"
+	gw.Namespace = "ns"
+	route := &gatewayApiv1.HTTPRoute{}
+	route.Name = "r"
+	route.Namespace = "ns"
+
+	// Single path: readable suffix, no hash.
+	nameSingle, _, _ := policyName(route, gw, []string{"/api"})
+	assert.Equal(t, "gw-r-api", nameSingle)
+
+	// Multi-path: first path + hash suffix.
+	nameMulti, _, _ := policyName(route, gw, []string{"/api", "/health"})
+	assert.Regexp(t, `^gw-r-api-[0-9a-f]{8}$`, nameMulti, "multi-path name must be {base}-{firstPath}-{hash}")
+
+	// Order must not matter.
+	nameReversed, _, _ := policyName(route, gw, []string{"/health", "/api"})
+	assert.Equal(t, nameMulti, nameReversed, "path order must not affect the AP name")
+
+	// Different path sets must produce different names.
+	nameOther, _, _ := policyName(route, gw, []string{"/api", "/admin"})
+	assert.NotEqual(t, nameMulti, nameOther, "different path sets must produce different names")
+
+	// Multi-path must never collide with single-path.
+	assert.NotEqual(t, nameMulti, nameSingle)
+}
+
+// TestTruncateName verifies the 253-char name length cap.
+func TestTruncateName(t *testing.T) {
+	short := "my-gateway-my-route-api"
+	assert.Equal(t, short, truncateName(short))
+
+	exact := strings.Repeat("a", 253)
+	assert.Equal(t, exact, truncateName(exact))
+
+	long := strings.Repeat("a", 254)
+	result := truncateName(long)
+	assert.Len(t, result, 253)
+	assert.Regexp(t, `^a{244}-[0-9a-f]{8}$`, result)
+
+	longA := strings.Repeat("a", 244) + strings.Repeat("x", 10)
+	longB := strings.Repeat("a", 244) + strings.Repeat("y", 10)
+	assert.NotEqual(t, truncateName(longA), truncateName(longB))
+}
+
+// TestRoutePolicyPrefixOverlap is the regression test for the false-negative in IsOrphaned.
+//
+// Scenario: gateway "gw" in "ns". Two routes once existed: "api" and "api-v2".
+// "api"    → AP "gw-api"
+// "api-v2" → AP "gw-api-v2"
+//
+// "api-v2" is deleted. Cleanup must identify "gw-api-v2" as orphaned.
+// The old HasPrefix logic found route "api", computed base "gw-api", and concluded
+// HasPrefix("gw-api-v2", "gw-api-") == true → not orphaned (wrong).
+// The new exact-match logic finds no rule in route "api" that produces "gw-api-v2" → orphaned (correct).
+func TestRoutePolicyPrefixOverlap(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("ns")
+	routeApi := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	staleAP := &istiosecurityv1.AuthorizationPolicy{}
+	staleAP.Name = "gw-api-v2"
+	staleAP.Namespace = "ns"
+	staleAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "api",
+	}
+	assert.True(t, w.IsOrphaned(staleAP, []gatewayApiv1.HTTPRoute{routeApi}),
+		"AP gw-api-v2 must be orphaned: route api exists but only produces gw-api, not gw-api-v2")
+
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = "gw-api"
+	liveAP.Namespace = "ns"
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "api",
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{routeApi}),
+		"AP gw-api must NOT be orphaned: route api still produces it")
+}

--- a/pkg/controllers/writers/istio_l7_test.go
+++ b/pkg/controllers/writers/istio_l7_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -58,6 +59,165 @@ func testCIDRs(name, namespace string, cidrs ...string) *ipamv1alpha1.CIDRs {
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: cidrs},
 	}
+}
+
+// TestIstioPathsForRule verifies correct translation of HTTPRoute path match types.
+func TestIstioPathsForRule(t *testing.T) {
+	prefix := gatewayApiv1.PathMatchPathPrefix
+	exact := gatewayApiv1.PathMatchExact
+	regex := gatewayApiv1.PathMatchRegularExpression
+
+	api := "/api"
+	root := "/"
+	chaos := "/chaos"
+
+	tests := []struct {
+		name     string
+		matches  []gatewayApiv1.HTTPRouteMatch
+		expected []string
+	}{
+		{
+			name: "PathPrefix /api → /api and /api/*",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &api}},
+			},
+			expected: []string{"/api", "/api/*"},
+		},
+		{
+			name: "PathPrefix / → /* only (no double slash)",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &root}},
+			},
+			expected: []string{"/*"},
+		},
+		{
+			name: "Exact /chaos → /chaos only",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &exact, Value: &chaos}},
+			},
+			expected: []string{"/chaos"},
+		},
+		{
+			name: "RegularExpression → skipped",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &regex, Value: &api}},
+			},
+			expected: nil,
+		},
+		{
+			name: "nil type defaults to PathPrefix",
+			matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Value: &api}},
+			},
+			expected: []string{"/api", "/api/*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newIstioL7Writer(fake.NewClientBuilder().WithScheme(istioL7Scheme).Build())
+			assert.ElementsMatch(t, tc.expected, w.TranslatePaths(tc.matches))
+		})
+	}
+}
+
+// TestIsOrphaned_GranularityHost verifies that a route with granularity=host produces
+// the base AP name (no path suffix), and that orphan detection recognises it as live.
+func TestIsOrphaned_GranularityHost(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("ns")
+	prefix := gatewayApiv1.PathMatchPathPrefix
+	path := "/api"
+	route := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{"ipam.adevinta.com/granularity": "host"},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+			Rules: []gatewayApiv1.HTTPRouteRule{
+				{Matches: []gatewayApiv1.HTTPRouteMatch{
+					{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &path}},
+				}},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	// AP at base name (no path suffix) — what Apply actually creates for granularity=host.
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = "gw-my-route"
+	liveAP.Namespace = "ns"
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{route}),
+		"granularity=host AP at base name must NOT be orphaned")
+
+	// AP at path-suffixed name — what the old logic would have computed (bug).
+	staleAP := &istiosecurityv1.AuthorizationPolicy{}
+	staleAP.Name = "gw-my-route-api-" // some hash-suffixed name
+	staleAP.Namespace = "ns"
+	staleAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.True(t, w.IsOrphaned(staleAP, []gatewayApiv1.HTTPRoute{route}),
+		"path-suffixed AP must be orphaned when route uses granularity=host")
+}
+
+// TestIsOrphaned_PathPrefixRoute verifies that orphan detection correctly resolves the AP name
+// for a PathPrefix route (which expands to two paths and gets a hash-suffixed name).
+func TestIsOrphaned_PathPrefixRoute(t *testing.T) {
+	gwNS := gatewayApiv1.Namespace("ns")
+	prefix := gatewayApiv1.PathMatchPathPrefix
+	path := "/api"
+	route := gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "ns"},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "gw", Namespace: &gwNS},
+			}},
+			Rules: []gatewayApiv1.HTTPRouteRule{
+				{Matches: []gatewayApiv1.HTTPRouteMatch{
+					{Path: &gatewayApiv1.HTTPPathMatch{Type: &prefix, Value: &path}},
+				}},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	// Compute the name Apply would actually create.
+	targets := w.policyTargetsForRoute(&route)
+	require.Len(t, targets, 1)
+	liveAPName := targets[0].name
+
+	liveAP := &istiosecurityv1.AuthorizationPolicy{}
+	liveAP.Name = liveAPName
+	liveAP.Namespace = "ns"
+	liveAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.False(t, w.IsOrphaned(liveAP, []gatewayApiv1.HTTPRoute{route}),
+		"PathPrefix AP at correct hash name must NOT be orphaned")
+
+	// The old (pre-fix) name using only the raw path value.
+	oldAP := &istiosecurityv1.AuthorizationPolicy{}
+	oldAP.Name = "gw-my-route-api" // single-path name, no hash
+	oldAP.Namespace = "ns"
+	oldAP.Labels = map[string]string{
+		"ipam.adevinta.com/owner-namespace": "ns",
+		"ipam.adevinta.com/owner-name":      "my-route",
+	}
+	assert.True(t, w.IsOrphaned(oldAP, []gatewayApiv1.HTTPRoute{route}),
+		"old single-path AP name must be orphaned after PathPrefix expansion fix")
 }
 
 // TestPolicyNameMultiPathNoCollision verifies the AP naming scheme for multi-path rules.


### PR DESCRIPTION
Idea is to make it more modular.
for ex.: to add Traefik (or NGinx GF, Kong) in the future,  interface(s) got implemented.
so we can just register in controllers.go - and nothing else changes.

NEW:
* separate k8s writers (istio_l4 / istio_l7 / istio_l7_merge)
* create tests accordingly
* RBAC fails on start when permissions are missing - each writers must expose `RequiredPermissions` info
   this is very useful for debugging
* introduce README2.md for deeper dive about conventions, controller support matrix etc.
* gateway class auto detection -> pick equivalent writer