### PR TITLE
fix(#21): BOM sequence in CSV - fix first IP

### DIFF
--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -128,16 +128,13 @@ func applyProcessor(reader io.Reader, processing ipamv1alpha1.Processing) ([]str
 	}
 }
 
-func newBOMStripper(r io.Reader) io.Reader {
-	br := bufio.NewReader(r)
+func processCSV(reader io.Reader, processing ipamv1alpha1.Processing) ([]string, error) {
+	// remove Byte Order Mark
+	br := bufio.NewReader(reader)
 	if b, err := br.Peek(3); err == nil && b[0] == 0xef && b[1] == 0xbb && b[2] == 0xbf {
 		_, _ = br.Discard(3)
 	}
-	return br
-}
-
-func processCSV(reader io.Reader, processing ipamv1alpha1.Processing) ([]string, error) {
-	data := csv.NewReader(newBOMStripper(reader))
+	data := csv.NewReader(br)
 	data.Comment = '#'        // Ignore comments
 	data.FieldsPerRecord = -1 // Disable strict field count checking
 	data.LazyQuotes = true    // Allow unescaped quotes inside fields

--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/csv"
@@ -127,8 +128,16 @@ func applyProcessor(reader io.Reader, processing ipamv1alpha1.Processing) ([]str
 	}
 }
 
+func newBOMStripper(r io.Reader) io.Reader {
+	br := bufio.NewReader(r)
+	if b, err := br.Peek(3); err == nil && b[0] == 0xef && b[1] == 0xbb && b[2] == 0xbf {
+		_, _ = br.Discard(3)
+	}
+	return br
+}
+
 func processCSV(reader io.Reader, processing ipamv1alpha1.Processing) ([]string, error) {
-	data := csv.NewReader(reader)
+	data := csv.NewReader(newBOMStripper(reader))
 	data.Comment = '#'        // Ignore comments
 	data.FieldsPerRecord = -1 // Disable strict field count checking
 	data.LazyQuotes = true    // Allow unescaped quotes inside fields

--- a/pkg/controllers/cidrs_controller_test.go
+++ b/pkg/controllers/cidrs_controller_test.go
@@ -653,6 +653,47 @@ func TestCIDRsReconcileFromCombinedSeparatedValues(t *testing.T) {
 	assert.Equal(t, []string{"1.1.1.1/32", "10.1.0.0/24", "10.2.0.0/24", "10.3.0.0/24", "10.4.0.0/24", "200.1.1.1/24"}, cidrs.GetStatus().CIDRs)
 }
 
+func TestCIDRsReconcileFromCSVWithBOM(t *testing.T) {
+	ctx := context.TODO()
+	testNamespaceName := "mynamespace"
+	scheme, err := Scheme("")
+	require.NoError(t, err)
+
+	// Akamai-style CSV: UTF-8 BOM at the start, trailing spaces, CRLF line endings.
+	// The BOM causes the first CIDR to be silently dropped without BOM stripping.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("\xef\xbb\xbf2.16.0.0/13  \r\n23.0.0.0/12  \r\n23.192.0.0/11  \r\n"))
+	}))
+	defer server.Close()
+
+	cidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-net", Namespace: testNamespaceName},
+		Spec: ipamv1alpha1.CIDRsSpec{CIDRsSource: ipamv1alpha1.CIDRsSource{
+			Location: ipamv1alpha1.CIDRsLocation{
+				URI: server.URL,
+				Processing: ipamv1alpha1.Processing{
+					Format: "CSV",
+				},
+			},
+		}},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cidrs).WithStatusSubresource(cidrs).Build()
+	reconciler := &CIDRReconciler{
+		CIDRs:     &ipamv1alpha1.CIDRs{},
+		CIDRsList: &ipamv1alpha1.CIDRsList{},
+		Client:    fakeClient,
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cidrs)})
+	require.NoError(t, err)
+	require.Equal(t, result, reconcile.Result{})
+
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(cidrs), cidrs))
+
+	assert.Equal(t, []string{"2.16.0.0/13", "23.0.0.0/12", "23.192.0.0/11"}, cidrs.GetStatus().CIDRs)
+}
+
 func TestCIDRsReconcileFromCombinedComplexSeparatedValues(t *testing.T) {
 	ctx := context.TODO()
 	testNamespaceName := "mynamespace"


### PR DESCRIPTION
Some vendors (like Akamai) provides Byte Order Mark (`ef bb bf`) in the beginning of the file.
In order to read first IP we need to clean the BOM.