### PR TITLE
fix(#23): GetCidrsFromObject generates uniq and sorted list

### DIFF
--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -276,7 +276,7 @@ func TestCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		func() bool {
 			ing := &netv1.Ingress{}
 			require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Namespace: currentNamespaceName, Name: "ing1"}, ing))
-			return ing.Annotations["nginx.ingress.kubernetes.io/whitelist-source-range"] == "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+			return ing.Annotations["nginx.ingress.kubernetes.io/whitelist-source-range"] == "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 		},
 		5*time.Second,
 		100*time.Millisecond,
@@ -429,7 +429,7 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 				return false
 			}
 			actual := generatedAuthorizationPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks
-			expected := []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}
+			expected := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
 			return reflect.DeepEqual(actual, expected)
 		},
 		5*time.Second,
@@ -524,7 +524,7 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 				return false
 			}
 			actual := generatedAuthorizationPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks
-			expected := []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"}
+			expected := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
 			return reflect.DeepEqual(actual, expected)
 		},
 		5*time.Second,

--- a/pkg/controllers/gateway_controller_test.go
+++ b/pkg/controllers/gateway_controller_test.go
@@ -624,6 +624,40 @@ func TestGatewayAnnotationRemovalDeletesAP(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "AP must be deleted after gateway annotation is removed")
 }
 
+// TestReconcileGatewayDuplicateCIDRsAcrossGroups verifies that when multiple groups share
+// common CIDRs, the generated AuthorizationPolicy contains each CIDR only once.
+func TestReconcileGatewayDuplicateCIDRsAcrossGroups(t *testing.T) {
+	sharedCIDR := "10.0.0.0/8"
+	staticAkamai := &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "static-akamai"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{sharedCIDR, "1.2.3.0/24"}},
+	}
+	dynamicAkamai := &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "dynamic-akamai"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{sharedCIDR, "5.6.7.0/24"}},
+	}
+	gwClass := newGatewayClass("istio")
+	gateway := &gatewayApiv1.Gateway{
+		ObjectMeta: v1.ObjectMeta{Namespace: "mynamespace", Name: "test", Annotations: map[string]string{
+			"ipam.adevinta.com/cluster-allowlist-group": "static-akamai,dynamic-akamai",
+		}},
+		Spec: gatewayApiv1.GatewaySpec{GatewayClassName: "istio"},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(gateway, staticAkamai, dynamicAkamai, gwClass).Build()
+	reconciler := newGatewayReconciler(t, k8sClient, extendedScheme)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "test", Namespace: "mynamespace"}})
+	assert.NoError(t, err)
+
+	generatedAuthorizationPolicy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "test", Namespace: "mynamespace"}, generatedAuthorizationPolicy)
+	assert.NoError(t, err)
+
+	remoteIpBlocks := generatedAuthorizationPolicy.Spec.Rules[0].From[0].Source.RemoteIpBlocks
+	assert.ElementsMatch(t, []string{sharedCIDR, "1.2.3.0/24", "5.6.7.0/24"}, remoteIpBlocks,
+		"shared CIDRs across groups must not be duplicated in the AuthorizationPolicy")
+}
+
 // TestReconcileGatewayClassDeletedCleansUpAP verifies that when a GatewayClass is deleted,
 // the gateway controller still cleans up the AuthorizationPolicy rather than leaving it orphaned.
 func TestReconcileGatewayClassDeletedCleansUpAP(t *testing.T) {

--- a/pkg/controllers/ingress_controller_test.go
+++ b/pkg/controllers/ingress_controller_test.go
@@ -88,7 +88,7 @@ func TestReconcileIngress(t *testing.T) {
 			Annotations: map[string]string{
 				"ipam.adevinta.com/allowlist-group":                  "localnet,dnssource",
 				"ipam.adevinta.com/cluster-allowlist-group":          "globalnet",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,1.1.1.1/32,8.8.8.8/32,15.13.12.0/24",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "1.1.1.1/32,10.0.0.0/8,15.13.12.0/24,172.16.0.0/12,192.168.0.0/16,8.8.8.8/32",
 			},
 		},
 	}
@@ -127,7 +127,7 @@ func TestReconcileIngressWithClusterCIDR(t *testing.T) {
 			ResourceVersion: "999",
 			Annotations: map[string]string{
 				"ipam.adevinta.com/cluster-allowlist-group":          "globalnet,anotherglobalnet",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,15.13.12.0/24",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "10.0.0.0/8,15.13.12.0/24,172.16.0.0/12,192.168.0.0/16",
 			},
 		},
 	}
@@ -178,7 +178,7 @@ func TestReconcileIngressPartialNotFound(t *testing.T) {
 			ResourceVersion: "999",
 			Annotations: map[string]string{
 				"ipam.adevinta.com/allowlist-group":                  "localnet,notexisting",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestReconcileIngressWithInvalidCIDRIpsNoError(t *testing.T) {
 			ResourceVersion: "999",
 			Annotations: map[string]string{
 				"ipam.adevinta.com/allowlist-group":                  "localnet,dnssource",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "172.16.0.0/12,10.0.0.0/8,1.1.1.1/32,8.8.8.8/32",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "1.1.1.1/32,10.0.0.0/8,172.16.0.0/12,8.8.8.8/32",
 			},
 		},
 	}
@@ -347,7 +347,7 @@ func TestReconcileIngressOverwriteAllowlist(t *testing.T) {
 			Annotations: map[string]string{
 				"ipam.adevinta.com/allowlist-group":                  "localnet",
 				"ipam.adevinta.com/cluster-allowlist-group":          "globalnet",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,1.2.3.0/24",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "1.2.3.0/24,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
 			},
 		},
 	}
@@ -410,7 +410,7 @@ func TestReconcileIngressInvalidAnnotationFormat(t *testing.T) {
 			ResourceVersion: "999",
 			Annotations: map[string]string{
 				"ipam.adevinta.com/allowlist-group":                  "localnet, dnssource",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,1.1.1.1/32,8.8.8.8/32",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "1.1.1.1/32,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,8.8.8.8/32",
 			},
 		},
 	}
@@ -443,7 +443,7 @@ func TestReconcileIngressV1(t *testing.T) {
 			ResourceVersion: "999",
 			Annotations: map[string]string{
 				"ipam.adevinta.com/allowlist-group":                  "localnet,dnssource",
-				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,1.1.1.1/32,8.8.8.8/32",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "1.1.1.1/32,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,8.8.8.8/32",
 			},
 		},
 	}

--- a/pkg/controllers/writers/istio_l7.go
+++ b/pkg/controllers/writers/istio_l7.go
@@ -8,7 +8,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -18,6 +17,7 @@ import (
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/controllers/internal"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/util"
 	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
 
@@ -83,7 +83,7 @@ func policyName(route *gatewayApiv1.HTTPRoute, gateway *gatewayApiv1.Gateway, pa
 	name = baseName
 	if len(paths) > 0 {
 		h := fnv.New32a()
-		for _, p := range dedupSorted(paths) {
+		for _, p := range util.DedupSorted(paths) {
 			_, _ = h.Write([]byte(p))
 		}
 		name = fmt.Sprintf("%s-%08x", baseName, h.Sum32())
@@ -112,7 +112,7 @@ func policyNameSuffix(paths []string) string {
 		return ""
 	}
 	h := fnv.New32a()
-	for _, p := range dedupSorted(paths) {
+	for _, p := range util.DedupSorted(paths) {
 		_, _ = h.Write([]byte(p))
 	}
 	return fmt.Sprintf("-%08x", h.Sum32())
@@ -354,7 +354,3 @@ func (w *IstioL7Writer) TranslatePaths(matches []gatewayApiv1.HTTPRouteMatch) []
 	return paths
 }
 
-// dedupSorted returns a sorted, deduplicated copy of the input slice.
-func dedupSorted(items []string) []string {
-	return sets.List(sets.New[string](items...))
-}

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -9,6 +9,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/util"
+
 	istioApiSecurityV1 "istio.io/api/security/v1"
 	istioApiTypeV1beta1 "istio.io/api/type/v1beta1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
@@ -51,14 +53,14 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 			continue
 		}
 
-		sortedIPs := dedupSorted(ips)
+		sortedIPs := util.DedupSorted(ips)
 		cidrKey := strings.Join(sortedIPs, ",")
 
 		var rawHosts []string
 		for _, h := range sibling.Spec.Hostnames {
 			rawHosts = append(rawHosts, string(h))
 		}
-		hosts := dedupSorted(rawHosts)
+		hosts := util.DedupSorted(rawHosts)
 		hostKey := strings.Join(hosts, ",")
 
 		granularity := sibling.Annotations[granularityAnnotation]
@@ -81,7 +83,7 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 			continue
 		}
 		for _, rule := range sibling.Spec.Rules {
-			paths := dedupSorted(w.TranslatePaths(rule.Matches))
+			paths := util.DedupSorted(w.TranslatePaths(rule.Matches))
 			tuples = append(tuples, mergedTuple{
 				cidrKey: cidrKey, hostKey: hostKey,
 				cidrs: sortedIPs, hosts: hosts,
@@ -147,7 +149,7 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 				op.Hosts = hosts
 			}
 			if !hg.unrestricted && len(hg.paths) > 0 {
-				op.Paths = dedupSorted(hg.paths)
+				op.Paths = util.DedupSorted(hg.paths)
 			}
 			if op.Hosts != nil || op.Paths != nil {
 				rule.To = append(rule.To, &istioApiSecurityV1.Rule_To{Operation: op})
@@ -194,7 +196,7 @@ func mergeTosByPaths(tos []*istioApiSecurityV1.Rule_To) []*istioApiSecurityV1.Ru
 		if to.Operation == nil {
 			continue
 		}
-		pathKey := strings.Join(dedupSorted(to.Operation.Paths), ",")
+		pathKey := strings.Join(util.DedupSorted(to.Operation.Paths), ",")
 		g, exists := byPathKey[pathKey]
 		if !exists {
 			g = &group{}
@@ -209,7 +211,7 @@ func mergeTosByPaths(tos []*istioApiSecurityV1.Rule_To) []*istioApiSecurityV1.Ru
 		g := byPathKey[pathKey]
 		op := &istioApiSecurityV1.Operation{}
 		if len(g.hosts) > 0 {
-			op.Hosts = dedupSorted(g.hosts)
+			op.Hosts = util.DedupSorted(g.hosts)
 		}
 		if pathKey != "" {
 			op.Paths = strings.Split(pathKey, ",")

--- a/pkg/resolvers/cidr_resolver.go
+++ b/pkg/resolvers/cidr_resolver.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/adevinta/go-log-toolkit"
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
 	ipamv1alpha1_legacy "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/legacy/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -204,5 +205,5 @@ func (r *CidrResolver) GetCidrsFromObject(ctx context.Context, object client.Obj
 		}
 		allowedIps = append(allowedIps, allowedClusterIps...)
 	}
-	return allowedIps, nil
+	return util.DedupSorted(allowedIps), nil
 }

--- a/pkg/resolvers/cidr_resolver_test.go
+++ b/pkg/resolvers/cidr_resolver_test.go
@@ -78,7 +78,7 @@ func TestGetCidrsFromObject(t *testing.T) {
 	ingress := &netv1.Ingress{
 		ObjectMeta: v1.ObjectMeta{Name: "myingress", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet, dnslocal"}},
 	}
-	expected := []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8", "8.8.8.8/32", "1.1.1.1/32"}
+	expected := []string{"1.1.1.1/32", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "8.8.8.8/32"}
 
 	cidrResolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
 
@@ -124,7 +124,7 @@ func TestGetCidrsFromObjectWithCidrsAndClusterCidrs(t *testing.T) {
 	ingress := &netv1.Ingress{
 		ObjectMeta: v1.ObjectMeta{Name: "myingress", Namespace: "mynamespace", Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet", "ipam.adevinta.com/cluster-allowlist-group": "dnslocal"}},
 	}
-	expected := []string{"192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8", "8.8.8.8/32", "1.1.1.1/32"}
+	expected := []string{"1.1.1.1/32", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "8.8.8.8/32"}
 
 	cidrResolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
 

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -1,0 +1,8 @@
+package util
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// DedupSorted returns a sorted, deduplicated copy of the input slice.
+func DedupSorted(items []string) []string {
+	return sets.List(sets.New[string](items...))
+}

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDedupSorted(t *testing.T) {
+	t.Run("deduplicates and sorts", func(t *testing.T) {
+		assert.Equal(t, []string{"a", "b", "c"}, DedupSorted([]string{"c", "a", "b", "a"}))
+	})
+
+	t.Run("empty input returns empty slice", func(t *testing.T) {
+		assert.Empty(t, DedupSorted([]string{}))
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		assert.Equal(t, []string{"x"}, DedupSorted([]string{"x"}))
+	})
+
+	t.Run("all duplicates collapses to one", func(t *testing.T) {
+		assert.Equal(t, []string{"10.0.0.0/8"}, DedupSorted([]string{"10.0.0.0/8", "10.0.0.0/8", "10.0.0.0/8"}))
+	})
+
+	t.Run("no duplicates preserves all elements sorted", func(t *testing.T) {
+		assert.Equal(t, []string{"1.1.1.1/32", "10.0.0.0/8", "192.168.0.0/16"}, DedupSorted([]string{"192.168.0.0/16", "10.0.0.0/8", "1.1.1.1/32"}))
+	})
+}


### PR DESCRIPTION
* New shared utility - `pkg/util/slices.go` with exported `DedupSorted([]string) []string`. (function we already have, to reuse it we have to move it for common lib) + test

* Test created introducing expected CIDR strings across ingress_controller_test.go, controllers_test.go, and cidr_resolver_test.go updated to the new sorted order.

* Bug fix - `pkg/resolvers/cidr_resolver.go`: `GetCidrsFromObject` now calls `util.DedupSorted(allowedIps)` before returning, eliminating duplicates (and sorting as a side effect) across all groups and annotation types.

* Adapt tests for having sorted output