### PR TITLE
feat(): traefik support

### DIFF
--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -24,6 +24,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -54,6 +55,7 @@ func main() {
 	ctx := mainContext
 	var metricsAddr string
 	var enableLeaderElection bool
+	var ingressSupportEnabled bool
 	var gatewaySupportEnabled bool
 	var networkPolicySupportEnabled bool
 	var httpRouteSupportEnabled bool
@@ -66,6 +68,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&ingressSupportEnabled, "ingress-support-enabled", true, "Enable Ingress support for the controller")
 	flag.BoolVar(&gatewaySupportEnabled, "gateway-support-enabled", false, "Enable gateway support for the controller")
 	flag.BoolVar(&networkPolicySupportEnabled, "networkpolicy-support-enabled", false, "Enable networkpolicy support for the controller")
 	flag.BoolVar(&httpRouteSupportEnabled, "httproute-support-enabled", false, "Enable HTTPRoute support for the controller")
@@ -90,8 +93,19 @@ func main() {
 		restConfig.Impersonate.UserName = as
 	}
 
+	// Build a REST mapper from the rest config for pre-flight CRD detection.
+	// This runs before the manager starts, so we can't use mgr.GetRESTMapper() yet.
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		setupLog.Fatal(err, "unable to create http client for REST mapper")
+	}
+	preflightMapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
+	if err != nil {
+		setupLog.Fatal(err, "unable to create REST mapper for preflight")
+	}
+
 	// nil client is fine here — writers are only used to call RequiredPermissions(), not for K8s ops.
-	l4Writers, l7Writers := controllers.BuildWriterRegistries(nil, "preflight", annotationPrefix)
+	l4Writers, l7Writers := controllers.BuildWriterRegistries(nil, preflightMapper, "preflight", annotationPrefix)
 	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, httpHeadersEnabled, l4Writers, l7Writers)
 
 	mgrOptions := ctrl.Options{
@@ -129,7 +143,7 @@ func main() {
 		setupLog.Fatal(err, "unable to start manager")
 	}
 
-	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix, httpHeadersEnabled); err != nil {
+	if err = controllers.SetupControllersWithManager(mgr, ingressSupportEnabled, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix, httpHeadersEnabled); err != nil {
 		setupLog.Fatal(err, "unable to setup controllers")
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,10 +18,18 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - httproutes
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ipam.adevinta.com
@@ -69,5 +77,16 @@ rules:
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - traefik.io
+  resources:
+  - middlewares
+  verbs:
+  - create
+  - delete
+  - get
+  - list
   - update
   - watch

--- a/helm-chart/ingress-allowlisting-controller/Chart.yaml
+++ b/helm-chart/ingress-allowlisting-controller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for managing Ingress Controller Allowlisting in namespaces
 name: ingress-allowlisting-controller
-version: 0.1.4
+version: 0.1.5

--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         image: {{ .Values.image.fullyQualifiedURL }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         args:
+{{- if not .Values.ingress.enabled }}
+        - "--ingress-support-enabled=false"
+{{- end }}
 {{- if .Values.gateway.enabled }}
         - "--gateway-support-enabled"
 {{- end }}

--- a/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
@@ -17,16 +17,19 @@ rules:
   - "cidrs/status"
   - "clustercidrs/status"
   verbs: ["get", "list", "watch", "create", "update", "patch"]
+{{- if .Values.ingress.enabled }}
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
-  verbs: ["list","get", "update", "watch"]
+  verbs: ["list", "get", "update", "watch"]
 - apiGroups: ["networking.k8s.io"]
-  resources:
-  - "ingresses"
-{{- if .Values.networkpolicy.enabled }}
-  - "networkpolicies"
+  resources: ["ingresses"]
+  verbs: ["list", "get", "update", "watch"]
 {{- end }}
-  verbs: ["list","get", "update", "watch"]
+{{- if .Values.networkpolicy.enabled }}
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["list", "get", "update", "watch"]
+{{- end }}
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["list","get", "update", "create", "watch"]
@@ -45,11 +48,17 @@ rules:
 {{- end }}
 {{- if .Values.httproute.enabled }}
 - apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["httproutes", "gateways", "gatewayclasses"]
-  verbs: ["list","get", "watch"]
+  resources: ["httproutes"]
+  verbs: ["list", "get", "watch", "update"]
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["gateways", "gatewayclasses"]
+  verbs: ["list", "get", "watch"]
 - apiGroups: ["security.istio.io"]
   resources: ["authorizationpolicies"]
   verbs: ["list", "get", "watch", "create", "update", "delete", "patch"]
+- apiGroups: ["traefik.io"]
+  resources: ["middlewares"]
+  verbs: ["list", "get", "watch", "create", "update", "delete"]
 {{- end }}
 ---
 apiVersion: v1

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -21,6 +21,9 @@ vpa:
       cpu: 100m
       memory: 128M
 
+ingress:
+  enabled: true
+
 gateway:
   enabled: false
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -2,8 +2,10 @@ package controllers
 
 import (
 	"github.com/go-logr/logr"
+	log "github.com/adevinta/go-log-toolkit"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,6 +23,16 @@ import (
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+var setupLog = log.DefaultLogger.WithField("setup", "controllers")
+
+// isCRDInstalled returns true when the given GVK exists in the cluster's REST API.
+// Used at startup to auto-detect optional dependencies (Istio, Traefik) — any
+// combination is supported: neither, either, or both.
+func isCRDInstalled(mapper meta.RESTMapper, group, version, kind string) bool {
+	_, err := mapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, version)
+	return err == nil
+}
+
 type setupError struct {
 	error
 	controllerType string
@@ -30,29 +42,35 @@ func (e *setupError) Log(logger logr.Logger) {
 	logger.Error(e, "unable to create controller", "controller", e.controllerType)
 }
 
-// BuildWriterRegistries constructs the L4 and L7 writer registries based on which controllers
-// are enabled. Called from main.go before the manager starts so permissions can be checked.
-func BuildWriterRegistries(c client.Client, managedBy, annotationPrefix string) (writers.L4WriterRegistry, writers.L7WriterRegistry) {
+// BuildWriterRegistries constructs the L4 and L7 writer registries for the CRDs that are
+// actually installed on the cluster. Called from main.go before the manager starts so
+// permissions can be checked. Pass the REST mapper from the pre-flight client.
+func BuildWriterRegistries(c client.Client, mapper meta.RESTMapper, managedBy, annotationPrefix string) (writers.L4WriterRegistry, writers.L7WriterRegistry) {
 	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: c}
-	l4 := writers.L4WriterRegistry{
-		writers.IstioControllerName: writers.NewIstioL4Writer(c),
+	l4 := writers.L4WriterRegistry{}
+	l7 := writers.L7WriterRegistry{}
+	if isCRDInstalled(mapper, "security.istio.io", "v1", "AuthorizationPolicy") {
+		l4[writers.IstioControllerName] = writers.NewIstioL4Writer(c)
+		l7[writers.IstioControllerName] = writers.NewIstioL7Writer(c, managedBy, cidrResolver)
 	}
-	l7 := writers.L7WriterRegistry{
-		writers.IstioControllerName: writers.NewIstioL7Writer(c, managedBy, cidrResolver),
+	if isCRDInstalled(mapper, "traefik.io", "v1alpha1", "Middleware") {
+		l7[writers.TraefikControllerName] = writers.NewTraefikL7Writer(c, managedBy, cidrResolver)
 	}
 	return l4, l7
 }
 
-func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string, httpHeadersEnabled bool) error {
+func SetupControllersWithManager(mgr ctrl.Manager, ingressSupportEnabled bool, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string, httpHeadersEnabled bool) error {
 	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: mgr.GetClient()}
 
-	if err := (&IngressReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		LegacyGroupVersion: legacyGroupVersion,
-		CidrResolver:       cidrResolver,
-	}).SetupWithManager(mgr, namePrefix); err != nil {
-		return &setupError{error: err, controllerType: "Ingress"}
+	if ingressSupportEnabled {
+		if err := (&IngressReconciler{
+			Client:             mgr.GetClient(),
+			Scheme:             mgr.GetScheme(),
+			LegacyGroupVersion: legacyGroupVersion,
+			CidrResolver:       cidrResolver,
+		}).SetupWithManager(mgr, namePrefix); err != nil {
+			return &setupError{error: err, controllerType: "Ingress"}
+		}
 	}
 
 	if err := (&CIDRReconciler{
@@ -96,12 +114,18 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 		managedBy = namePrefix + "-ingress-allowlisting-controller"
 	}
 
-	l4Writers := writers.L4WriterRegistry{
-		writers.IstioControllerName: writers.NewIstioL4Writer(mgr.GetClient()),
+	mapper := mgr.GetRESTMapper()
+	l4Writers, l7Writers := BuildWriterRegistries(mgr.GetClient(), mapper, managedBy, annotationPrefix)
+
+	if _, ok := l4Writers[writers.IstioControllerName]; ok {
+		setupLog.Infof("detected Istio: enabling Istio writers")
 	}
-	l7Writers := writers.L7WriterRegistry{
-		writers.IstioControllerName: writers.NewIstioL7Writer(mgr.GetClient(), managedBy, cidrResolver),
-		//		writers.TraefikControllerName: writers.NewTraefikL7Writer(mgr.GetClient(), managedBy, cidrResolver),
+	if _, ok := l7Writers[writers.TraefikControllerName]; ok {
+		setupLog.Infof("detected Traefik: enabling Traefik writer")
+	}
+
+	if httpRouteSupportEnabled && len(l7Writers) == 0 {
+		setupLog.Warnf("httproute support is enabled but no L7 writer was detected (neither Istio nor Traefik CRDs found); HTTPRoutes will be reconciled but no allowlist resources will be written")
 	}
 
 	if gatewaySupportEnabled {
@@ -185,9 +209,9 @@ func Scheme(legacyGroupVersion string) (*runtime.Scheme, error) {
 	if err := istiosecurityv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	//	if err := writers.AddTraefikToScheme(scheme); err != nil {
-	//		return nil, err
-	//	}
+	if err := writers.AddTraefikToScheme(scheme); err != nil {
+		return nil, err
+	}
 
 	if legacyGroupVersion != "" {
 		var err error

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -473,7 +473,7 @@ func TestCIDRsControllerDoesNotWatchSecretsAndConfigMapsWhenDisabled(t *testing.
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.adevinta.com", false))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, false, "", t.Name(), "ipam.adevinta.com", false))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -524,7 +524,7 @@ func TestCIDRsControllerWatchesSecretsAndConfigMapsWhenEnabled(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.adevinta.com", true))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, false, "", t.Name(), "ipam.adevinta.com", true))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -38,6 +38,21 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
+// namespacedScope implements meta.RESTScope for namespace-scoped resources.
+type namespacedScope struct{}
+
+func (namespacedScope) Name() meta.RESTScopeName { return meta.RESTScopeNameNamespace }
+
+// schemeRESTMapper builds a DefaultRESTMapper that includes every GVK registered
+// in the scheme. All types are treated as namespaced (sufficient for isCRDInstalled checks).
+func schemeRESTMapper(s *runtime.Scheme) meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper(s.PrioritizedVersionsAllGroups())
+	for gvk := range s.AllKnownTypes() {
+		mapper.Add(gvk, namespacedScope{})
+	}
+	return mapper
+}
+
 type testHandlerRegistration struct{}
 
 func (r *testHandlerRegistration) HasSynced() bool { return true }
@@ -231,7 +246,7 @@ func TestCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 	mgr, err := manager.New(&rest.Config{}, manager.Options{
 		Scheme: extendedScheme,
 		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-			return meta.NewDefaultRESTMapper(extendedScheme.PrioritizedVersionsAllGroups()), nil
+			return schemeRESTMapper(extendedScheme), nil
 		},
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
 			return k8sClient, nil
@@ -241,7 +256,7 @@ func TestCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.example.com", true))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, false, "", t.Name(), "ipam.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -300,7 +315,7 @@ func TestClusterCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 	mgr, err := manager.New(&rest.Config{}, manager.Options{
 		Scheme: extendedScheme,
 		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-			return meta.NewDefaultRESTMapper(extendedScheme.PrioritizedVersionsAllGroups()), nil
+			return schemeRESTMapper(extendedScheme), nil
 		},
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
 			return k8sClient, nil
@@ -313,7 +328,7 @@ func TestClusterCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "legacy.example.com", true))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, false, "", t.Name(), "legacy.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -374,7 +389,7 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 	mgr, err := manager.New(&rest.Config{}, manager.Options{
 		Scheme: extendedScheme,
 		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-			return meta.NewDefaultRESTMapper(extendedScheme.PrioritizedVersionsAllGroups()), nil
+			return schemeRESTMapper(extendedScheme), nil
 		},
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
 			return k8sClient, nil
@@ -387,7 +402,7 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com", true))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -567,7 +582,7 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 	mgr, err := manager.New(&rest.Config{}, manager.Options{
 		Scheme: extendedScheme,
 		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-			return meta.NewDefaultRESTMapper(extendedScheme.PrioritizedVersionsAllGroups()), nil
+			return schemeRESTMapper(extendedScheme), nil
 		},
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
 			return k8sClient, nil
@@ -580,7 +595,7 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com", true))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))

--- a/pkg/controllers/gateway_controller.go
+++ b/pkg/controllers/gateway_controller.go
@@ -31,6 +31,7 @@ type GatewayAllowlistingReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=clustercidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -89,8 +90,11 @@ func (r *GatewayAllowlistingReconciler) Reconcile(ctx context.Context, req ctrl.
 
 func (r *GatewayAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
 	build := ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayApiv1.Gateway{}).
-		Owns(&istiosecurityv1.AuthorizationPolicy{}).
+		For(&gatewayApiv1.Gateway{})
+	if isCRDInstalled(mgr.GetRESTMapper(), "security.istio.io", "v1", "AuthorizationPolicy") {
+		build = build.Owns(&istiosecurityv1.AuthorizationPolicy{})
+	}
+	build = build.
 		Watches(
 			&ipamv1alpha1.CIDRs{},
 			handler.EnqueueRequestsFromMapFunc(newGatewaysFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation()))).

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -82,79 +82,33 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 	log.Infof("HTTPRoute %s being reconciled. Creating/updating writers...", httproute.GetName())
 
 	parentRefs := gateway.GatewayParentRefs(&httproute)
-	if len(parentRefs) == 0 {
-		log.Infof("HTTPRoute %s has no Gateway parentRefs, skipping", httproute.GetName())
-		return ctrl.Result{}, nil
-	}
 
-	if mergeKey := httproute.Annotations[r.mergeAnnotation()]; mergeKey != "" {
+	mergeKey := httproute.Annotations[r.mergeAnnotation()]
+	if mergeKey != "" {
 		if err := validateMergeKey(mergeKey); err != nil {
 			log.Errorf("HTTPRoute %s/%s has invalid merge key: %v", httproute.Namespace, httproute.GetName(), err)
 			return ctrl.Result{}, nil
 		}
-		for _, ref := range parentRefs {
-			gatewayNS := httproute.Namespace // nil Namespace means same namespace as the route
-			if ref.Namespace != nil {
-				gatewayNS = string(*ref.Namespace)
-			}
-			gateway := &gatewayApiv1.Gateway{}
-			if err := r.Get(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: gatewayNS}, gateway); err != nil {
-				if client.IgnoreNotFound(err) != nil {
-					return ctrl.Result{}, err
-				}
-				log.Infof("gateway %s/%s not found, skipping parentRef", gatewayNS, ref.Name)
-				continue
-			}
-			gwClass := &gatewayApiv1.GatewayClass{}
-			if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gwClass); err != nil {
-				if client.IgnoreNotFound(err) != nil {
-					return ctrl.Result{}, err
-				}
-				log.Infof("GatewayClass %s not found, skipping parentRef", gateway.Spec.GatewayClassName)
-				continue
-			}
-			writer, ok := r.L7Writers[string(gwClass.Spec.ControllerName)]
-			if !ok {
-				log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
-				continue
-			}
-			mw, ok := writer.(writers.MergeableL7PolicyWriter)
-			if !ok {
-				log.Infof("writer for controller %s does not support merge, skipping", gwClass.Spec.ControllerName)
-				continue
-			}
-			if err := r.reconcileMergedGateway(ctx, &httproute, gateway, mw, mergeKey); err != nil {
-				return ctrl.Result{}, err
-			}
+	} else {
+		// Route is not in merge mode — clean up any stale merged APs where this route was the last member.
+		if err := r.cleanupOrphanedMergedAPs(ctx, &httproute, parentRefs); err != nil {
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
 	}
 
-	// Route is not in merge mode — clean up any stale merged APs where this route was the last member.
-	if err := r.cleanupOrphanedMergedAPs(ctx, &httproute, parentRefs); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	allowedIps, err := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
-	if err == r.CidrResolver.AnnotationNotFoundError() {
-		// Annotation was removed — delete any APs that were previously created for this route.
-		for _, writer := range r.L7Writers {
-			if err := writer.DeleteForRoute(ctx, r.managedByValue(), httproute.Namespace, httproute.Name); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		return ctrl.Result{}, nil
-	}
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// Resolve CIDRs once — used by all per-route writers (always Traefik, Istio when no mergeKey).
+	allowedIps, cidrErr := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
 
 	var hostnames []string
 	for _, h := range httproute.Spec.Hostnames {
 		hostnames = append(hostnames, string(h))
 	}
-
 	granularity := httproute.Annotations[r.granularityAnnotation()]
+
+	// invokedWriters tracks which writers were used in this reconcile.
+	// Any registered writer not present here had its gateway removed from parentRefs
+	// and must have its stale policies cleaned up after the loop.
+	invokedWriters := map[string]struct{}{}
 
 	for _, ref := range parentRefs {
 		gatewayNS := httproute.Namespace
@@ -182,8 +136,30 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 			log.Infof("no L7 writer for controller %s, skipping", gwClass.Spec.ControllerName)
 			continue
 		}
+		controllerName := string(gwClass.Spec.ControllerName)
 
-		// Collect per-rule paths using the writer's translation (if it implements PathTranslator).
+		// Mergeable writers (e.g. Istio) with a merge annotation share one AP across the group.
+		// Non-mergeable writers (e.g. Traefik) always get a per-route policy regardless of mergeKey.
+		if mw, ok := writer.(writers.MergeableL7PolicyWriter); ok && mergeKey != "" {
+			invokedWriters[controllerName] = struct{}{}
+			if err := r.reconcileMergedGateway(ctx, &httproute, gateway, mw, mergeKey); err != nil {
+				return ctrl.Result{}, err
+			}
+			continue
+		}
+
+		// Per-route apply path — Traefik always, Istio when no mergeKey.
+		if cidrErr == r.CidrResolver.AnnotationNotFoundError() {
+			if err := writer.DeleteForRoute(ctx, r.managedByValue(), httproute.Namespace, httproute.Name); err != nil {
+				return ctrl.Result{}, err
+			}
+			invokedWriters[controllerName] = struct{}{}
+			continue
+		}
+		if cidrErr != nil {
+			return ctrl.Result{}, cidrErr
+		}
+
 		var rulePaths [][]string
 		if granularity == "" || granularity == "rule" {
 			rulePaths = make([][]string, len(httproute.Spec.Rules))
@@ -194,20 +170,20 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 
 		switch granularity {
 		case "host":
-			// One AP per route, host-matched, no path restriction.
+			// One policy per route, host-matched, no path restriction.
 			if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil); err != nil {
 				return ctrl.Result{}, err
 			}
 			log.Infof("policy (host) created/updated for HTTPRoute %s → gateway %s/%s", httproute.GetName(), gateway.Namespace, gateway.Name)
 		default:
-			// granularity=rule (default): one AP per HTTPRoute rule.
+			// granularity=rule (default): one policy per HTTPRoute rule.
 			for ruleIdx, paths := range rulePaths {
 				if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, paths); err != nil {
 					return ctrl.Result{}, err
 				}
 				log.Infof("policy (rule) created/updated for HTTPRoute %s rule %d → gateway %s/%s", httproute.GetName(), ruleIdx, gateway.Namespace, gateway.Name)
 			}
-			// Fallback: HTTPRoute with no rules — single AP, no path restriction.
+			// Fallback: HTTPRoute with no rules — single policy, no path restriction.
 			if len(rulePaths) == 0 {
 				if err := writer.Apply(ctx, r.Scheme, &httproute, gateway, allowedIps, hostnames, nil); err != nil {
 					return ctrl.Result{}, err
@@ -215,26 +191,41 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 				log.Infof("policy (rule/fallback) created/updated for HTTPRoute %s → gateway %s/%s", httproute.GetName(), gateway.Namespace, gateway.Name)
 			}
 		}
+		invokedWriters[controllerName] = struct{}{}
 	}
 
-	// Delete stale policies owned by this route that the current reconcile no longer produces
-	// (e.g. rule count reduced, or granularity changed from rule→host).
-	for _, writer := range r.L7Writers {
-		managed, err := writer.ListManaged(ctx, r.managedByValue())
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		for _, obj := range managed {
-			ownerNS := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
-			ownerName := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-name"]
-			if ownerNS != writers.LabelSafe(httproute.Namespace) || ownerName != writers.LabelSafe(httproute.Name) {
-				continue
+	// Delete all policies for writers that had no matching parentRef this reconcile.
+	// This fires when a gateway is removed from the route's parentRefs while the route itself still exists.
+	for controllerName, writer := range r.L7Writers {
+		if _, used := invokedWriters[controllerName]; !used {
+			if err := writer.DeleteForRoute(ctx, r.managedByValue(), httproute.Namespace, httproute.Name); err != nil {
+				return ctrl.Result{}, err
 			}
-			if writer.IsOrphaned(obj, []gatewayApiv1.HTTPRoute{httproute}) {
-				if err := writer.Delete(ctx, obj); err != nil {
-					return ctrl.Result{}, err
+			log.Infof("deleted stale policies for writer %s — no matching parentRef for HTTPRoute %s", controllerName, httproute.GetName())
+		}
+	}
+
+	// Delete stale per-route policies that this reconcile no longer produces
+	// (e.g. rule count reduced, granularity changed). Skipped for merge mode because
+	// mergeable writers manage their own AP lifecycle via ApplyMerged/DeleteMerged.
+	if mergeKey == "" {
+		for _, writer := range r.L7Writers {
+			managed, err := writer.ListManaged(ctx, r.managedByValue())
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			for _, obj := range managed {
+				ownerNS := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-namespace"]
+				ownerName := obj.GetLabels()[r.CidrResolver.AnnotationPrefix+"/owner-name"]
+				if ownerNS != writers.LabelSafe(httproute.Namespace) || ownerName != writers.LabelSafe(httproute.Name) {
+					continue
 				}
-				log.Infof("Deleted stale policy %s/%s for HTTPRoute %s", obj.GetNamespace(), obj.GetName(), httproute.GetName())
+				if writer.IsOrphaned(obj, []gatewayApiv1.HTTPRoute{httproute}) {
+					if err := writer.Delete(ctx, obj); err != nil {
+						return ctrl.Result{}, err
+					}
+					log.Infof("Deleted stale policy %s/%s for HTTPRoute %s", obj.GetNamespace(), obj.GetName(), httproute.GetName())
+				}
 			}
 		}
 	}

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -40,6 +40,7 @@ type HTTPRouteAllowlistingReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=clustercidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -40,10 +40,11 @@ type HTTPRouteAllowlistingReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=traefik.io,resources=middlewares,verbs=get;list;watch;create;update;delete
 
 func (r *HTTPRouteAllowlistingReconciler) mergeAnnotation() string {
 	return r.CidrResolver.AnnotationPrefix + "/merge"
@@ -539,8 +540,14 @@ func (r *HTTPRouteAllowlistingReconciler) SetupWithManager(mgr ctrl.Manager, nam
 	}
 
 	build := ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayApiv1.HTTPRoute{}, builder.WithPredicates(annotationPredicate)).
-		Owns(&istiosecurityv1.AuthorizationPolicy{}).
+		For(&gatewayApiv1.HTTPRoute{}, builder.WithPredicates(annotationPredicate))
+	if isCRDInstalled(mgr.GetRESTMapper(), "security.istio.io", "v1", "AuthorizationPolicy") {
+		build = build.Owns(&istiosecurityv1.AuthorizationPolicy{})
+	}
+	if isCRDInstalled(mgr.GetRESTMapper(), "traefik.io", "v1alpha1", "Middleware") {
+		build = build.Owns(&writers.TraefikMiddleware{})
+	}
+	build = build.
 		Watches(
 			&ipamv1alpha1.CIDRs{},
 			handler.EnqueueRequestsFromMapFunc(newHTTPRoutesFromCIDRFuncMap(r.Client, r.CidrResolver.Annotation()))).

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -1982,6 +1982,136 @@ func TestReconcileHTTPRouteMultipleGatewayClassesOneUnknown(t *testing.T) {
 
 // TestMergedAPUpdatesWhenSiblingCIDRsChange verifies that when a sibling's CIDRs change,
 // re-reconciling any route in the merge group picks up the updated IPs for all siblings.
+// TestReconcileHTTPRouteDualParentIstioAndTraefik verifies that an HTTPRoute with two parent
+// gateways — one Istio and one Traefik — creates both an Istio AuthorizationPolicy and a
+// Traefik Middleware in a single reconcile, without a merge annotation.
+func TestReconcileHTTPRouteDualParentIstioAndTraefik(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				parentRef("istio-gw", ""),
+				parentRef("traefik-gw", ""),
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+	istioGwClass := newIstioGatewayClass("istio")
+	traefikGwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "traefik"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: gatewayApiv1.GatewayController(writers.TraefikControllerName)},
+	}
+	istioGw := newTestGateway("istio-gw", "ns", "istio")
+	traefikGw := newTestGateway("traefik-gw", "ns", "traefik")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).
+		WithObjects(cidr, route, istioGwClass, traefikGwClass, istioGw, traefikGw).Build()
+
+	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	l7Writers := writers.L7WriterRegistry{
+		writers.IstioControllerName:   writers.NewIstioL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+		writers.TraefikControllerName: writers.NewTraefikL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+	}
+	reconciler := &HTTPRouteAllowlistingReconciler{
+		Client: k8sClient, APIReader: k8sClient,
+		CidrResolver: resolver, Scheme: extendedScheme, L7Writers: l7Writers,
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	// Istio AP must be created.
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "istio-gw-my-route", Namespace: "ns"}, ap)
+	assert.NoError(t, err, "Istio AuthorizationPolicy must be created for the Istio parent gateway")
+	assert.Equal(t, "istio-gw", ap.Spec.TargetRefs[0].Name)
+	assert.ElementsMatch(t, []string{"1.2.3.4/32"}, ap.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+
+	// Traefik Middleware must also be created.
+	mw := &writers.TraefikMiddleware{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "ns"}, mw)
+	assert.NoError(t, err, "Traefik Middleware must be created for the Traefik parent gateway")
+	assert.ElementsMatch(t, []string{"1.2.3.4/32"}, mw.Spec.IPAllowList.SourceRange)
+}
+
+// TestReconcileHTTPRouteMergeWithNonMergeWriter verifies that an HTTPRoute in merge mode
+// with two parent gateways — one Istio (merge-capable) and one Traefik (non-merge) —
+// creates both the merged Istio AuthorizationPolicy AND the Traefik Middleware.
+// Regression test: before the fix, the merge early-return skipped Traefik Apply entirely.
+func TestReconcileHTTPRouteMergeWithNonMergeWriter(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"1.2.3.4/32"}},
+	}
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "allowlist",
+				"ipam.adevinta.com/merge":           "my-group",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "istio-gw", Namespace: &gwNS},
+				parentRef("traefik-gw", ""),
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+
+	istioGwClass := newIstioGatewayClass("istio")
+	traefikGwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "traefik"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: gatewayApiv1.GatewayController(writers.TraefikControllerName)},
+	}
+	istioGw := newTestGateway("istio-gw", "gw-ns", "istio")
+	traefikGw := newTestGateway("traefik-gw", "ns", "traefik")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).
+		WithObjects(cidr, route, istioGwClass, traefikGwClass, istioGw, traefikGw).Build()
+
+	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	l7Writers := writers.L7WriterRegistry{
+		writers.IstioControllerName:   writers.NewIstioL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+		writers.TraefikControllerName: writers.NewTraefikL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+	}
+	reconciler := &HTTPRouteAllowlistingReconciler{
+		Client: k8sClient, APIReader: k8sClient,
+		CidrResolver: resolver, Scheme: extendedScheme, L7Writers: l7Writers,
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	// Istio: merged AP must be created in the gateway's namespace with name = merge key.
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-group", Namespace: "gw-ns"}, ap)
+	assert.NoError(t, err, "merged Istio AuthorizationPolicy must be created")
+	assert.Equal(t, "istio-gw", ap.Spec.TargetRefs[0].Name)
+	assert.ElementsMatch(t, []string{"1.2.3.4/32"}, ap.Spec.Rules[0].From[0].Source.RemoteIpBlocks)
+
+	// Traefik: per-route Middleware must also be created in the route's namespace.
+	mw := &writers.TraefikMiddleware{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "ns"}, mw)
+	assert.NoError(t, err, "Traefik Middleware must be created even when route is in merge mode")
+	assert.ElementsMatch(t, []string{"1.2.3.4/32"}, mw.Spec.IPAllowList.SourceRange)
+}
+
 func TestMergedAPUpdatesWhenSiblingCIDRsChange(t *testing.T) {
 	cidr00 := &ipamv1alpha1.CIDRs{
 		ObjectMeta: v1.ObjectMeta{Name: "allowlist", Namespace: "ns-a"},
@@ -2057,4 +2187,160 @@ func TestMergedAPUpdatesWhenSiblingCIDRsChange(t *testing.T) {
 		}
 	}
 	assert.ElementsMatch(t, []string{"1.1.1.1/32", "3.3.3.3/32"}, allIPs, "merged AP must reflect updated sibling CIDRs")
+}
+
+// TestPolicyDeletedWhenOneOfTwoParentRefsRemoved verifies that when an HTTPRoute has two parents
+// (Istio + Traefik) and one parentRef is removed, only the policy for the removed parent is deleted
+// while the policy for the remaining parent is kept.
+func TestPolicyDeletedWhenOneOfTwoParentRefsRemoved(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet"},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{
+					parentRef("istio-gw", ""),
+					parentRef("traefik-gw", ""),
+				},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+	istioGwClass := newIstioGatewayClass("istio")
+	traefikGwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "traefik"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: gatewayApiv1.GatewayController(writers.TraefikControllerName)},
+	}
+	istioGw := newTestGateway("istio-gw", "ns", "istio")
+	traefikGw := newTestGateway("traefik-gw", "ns", "traefik")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).
+		WithObjects(cidr, route, istioGwClass, traefikGwClass, istioGw, traefikGw).Build()
+
+	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	reconciler := &HTTPRouteAllowlistingReconciler{
+		Client: k8sClient, APIReader: k8sClient,
+		CidrResolver: resolver, Scheme: extendedScheme,
+		L7Writers: writers.L7WriterRegistry{
+			writers.IstioControllerName:   writers.NewIstioL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+			writers.TraefikControllerName: writers.NewTraefikL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+		},
+	}
+
+	// First reconcile — both AP and Middleware are created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "istio-gw-my-route", Namespace: "ns"}, ap), "Istio AP must exist after first reconcile")
+	mw := &writers.TraefikMiddleware{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "ns"}, mw), "Traefik Middleware must exist after first reconcile")
+
+	// Remove only the Traefik parentRef — Istio parent stays.
+	route.Spec.ParentRefs = []gatewayApiv1.ParentReference{parentRef("istio-gw", "")}
+	require.NoError(t, k8sClient.Update(context.Background(), route))
+
+	// Second reconcile — Traefik Middleware must be deleted, Istio AP must remain.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "istio-gw-my-route", Namespace: "ns"}, ap), "Istio AP must remain after Traefik parent removed")
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "ns"}, mw)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "Traefik Middleware must be deleted when its parentRef is removed")
+}
+
+// TestIstioAPDeletedWhenParentRefRemoved verifies that removing an Istio gateway parentRef from
+// an HTTPRoute causes the previously-created AuthorizationPolicy to be deleted on the next reconcile.
+func TestIstioAPDeletedWhenParentRefRemoved(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet"},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("istio-gw", "")},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("istio-gw", "ns", "istio")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, gwClass, gw).Build()
+	reconciler := newHTTPRouteReconciler(t, k8sClient, extendedScheme)
+
+	// First reconcile — AP is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	ap := &istiosecurityv1.AuthorizationPolicy{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "istio-gw-my-route", Namespace: "ns"}, ap), "AP must exist after first reconcile")
+
+	// Remove the Istio parentRef — route no longer points to the gateway.
+	route.Spec.ParentRefs = nil
+	require.NoError(t, k8sClient.Update(context.Background(), route))
+
+	// Second reconcile — AP must be deleted because the parent is gone.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "istio-gw-my-route", Namespace: "ns"}, ap)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "AP must be deleted when parentRef is removed")
+}
+
+// TestTraefikMiddlewareDeletedWhenParentRefRemoved verifies that removing a Traefik gateway
+// parentRef from an HTTPRoute causes the previously-created Middleware to be deleted on the next reconcile.
+func TestTraefikMiddlewareDeletedWhenParentRefRemoved(t *testing.T) {
+	cidr := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "ns"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-route", Namespace: "ns",
+			Annotations: map[string]string{"ipam.adevinta.com/allowlist-group": "localnet"},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{
+				ParentRefs: []gatewayApiv1.ParentReference{parentRef("traefik-gw", "")},
+			},
+			Hostnames: []gatewayApiv1.Hostname{"example.com"},
+		},
+	}
+	traefikGwClass := &gatewayApiv1.GatewayClass{
+		ObjectMeta: v1.ObjectMeta{Name: "traefik"},
+		Spec:       gatewayApiv1.GatewayClassSpec{ControllerName: gatewayApiv1.GatewayController(writers.TraefikControllerName)},
+	}
+	gw := newTestGateway("traefik-gw", "ns", "traefik")
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(cidr, route, traefikGwClass, gw).Build()
+
+	resolver := resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}
+	reconciler := &HTTPRouteAllowlistingReconciler{
+		Client: k8sClient, APIReader: k8sClient,
+		CidrResolver: resolver, Scheme: extendedScheme,
+		L7Writers: writers.L7WriterRegistry{
+			writers.TraefikControllerName: writers.NewTraefikL7Writer(k8sClient, "ingress-allowlisting-controller", resolver),
+		},
+	}
+
+	// First reconcile — Middleware is created.
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	mw := &writers.TraefikMiddleware{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "ns"}, mw), "Middleware must exist after first reconcile")
+
+	// Remove the Traefik parentRef — route no longer points to the gateway.
+	route.Spec.ParentRefs = nil
+	require.NoError(t, k8sClient.Update(context.Background(), route))
+
+	// Second reconcile — Middleware must be deleted because the parent is gone.
+	_, err = reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKey{Name: "my-route", Namespace: "ns"}})
+	require.NoError(t, err)
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "ns"}, mw)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "Middleware must be deleted when parentRef is removed")
 }

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -159,21 +160,27 @@ func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.G
 		rules = append(rules, rule)
 	}
 
-	policy := &istiosecurityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: mergeKey, Namespace: gateway.Namespace},
-	}
-	_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
-		w.applyLabels(policy, "MERGED", mergeKey)
-		policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
-			Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
-			Rules:  rules,
-			TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
-				{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
-			},
+	// Wrap in RetryOnConflict because sibling HTTPRoutes in the same merge group can reconcile
+	// concurrently: both call CreateOrUpdate on the same AuthorizationPolicy, one wins and bumps
+	// resourceVersion, the other gets a 409 conflict on Update. Re-creating the policy object
+	// inside the retry func ensures each attempt does a fresh Get with the latest resourceVersion.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		policy := &istiosecurityv1.AuthorizationPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: mergeKey, Namespace: gateway.Namespace},
 		}
-		return nil
+		_, err := ctrl.CreateOrUpdate(ctx, w.client, policy, func() error {
+			w.applyLabels(policy, "MERGED", mergeKey)
+			policy.Spec = istioApiSecurityV1.AuthorizationPolicy{
+				Action: istioApiSecurityV1.AuthorizationPolicy_ALLOW,
+				Rules:  rules,
+				TargetRefs: []*istioApiTypeV1beta1.PolicyTargetReference{
+					{Name: gateway.Name, Kind: "Gateway", Group: "gateway.networking.k8s.io"},
+				},
+			}
+			return nil
+		})
+		return err
 	})
-	return err
 }
 
 // DeleteMerged removes the merged AuthorizationPolicy for the given merge key.

--- a/pkg/controllers/writers/traefik_l7.go
+++ b/pkg/controllers/writers/traefik_l7.go
@@ -38,6 +38,7 @@ func NewTraefikL7Writer(c client.Client, managedBy string, cidrResolver resolver
 func (w *TraefikL7Writer) RequiredPermissions() []Permission {
 	return []Permission{
 		{Group: "traefik.io", Resource: "middlewares", Verb: "get"},
+		{Group: "traefik.io", Resource: "middlewares", Verb: "list"},
 		{Group: "traefik.io", Resource: "middlewares", Verb: "create"},
 		{Group: "traefik.io", Resource: "middlewares", Verb: "update"},
 		{Group: "traefik.io", Resource: "middlewares", Verb: "delete"},

--- a/pkg/controllers/writers/traefik_l7.go
+++ b/pkg/controllers/writers/traefik_l7.go
@@ -1,0 +1,204 @@
+package writers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+const TraefikControllerName = "traefik.io/gateway-controller"
+
+// TraefikL7Writer creates/deletes Traefik Middleware objects for HTTPRoute-level allowlisting.
+// It does not support merge (Traefik Middleware is attached per-route, not per-gateway).
+type TraefikL7Writer struct {
+	client           client.Client
+	managedBy        string
+	annotationPrefix string
+	cidrResolver     resolvers.CidrResolver
+}
+
+// NewTraefikL7Writer returns a new TraefikL7Writer.
+func NewTraefikL7Writer(c client.Client, managedBy string, cidrResolver resolvers.CidrResolver) *TraefikL7Writer {
+	return &TraefikL7Writer{
+		client:           c,
+		managedBy:        managedBy,
+		annotationPrefix: cidrResolver.AnnotationPrefix,
+		cidrResolver:     cidrResolver,
+	}
+}
+
+// RequiredPermissions returns the RBAC permissions needed by this writer.
+func (w *TraefikL7Writer) RequiredPermissions() []Permission {
+	return []Permission{
+		{Group: "traefik.io", Resource: "middlewares", Verb: "get"},
+		{Group: "traefik.io", Resource: "middlewares", Verb: "create"},
+		{Group: "traefik.io", Resource: "middlewares", Verb: "update"},
+		{Group: "traefik.io", Resource: "middlewares", Verb: "delete"},
+		{Group: "gateway.networking.k8s.io", Resource: "httproutes", Verb: "update"},
+	}
+}
+
+func (w *TraefikL7Writer) applyLabels(middleware *TraefikMiddleware, ownerNamespace, ownerName string) {
+	if middleware.Labels == nil {
+		middleware.Labels = map[string]string{}
+	}
+	middleware.Labels["app.kubernetes.io/managed-by"] = w.managedBy
+	middleware.Labels[w.annotationPrefix+"/owner-namespace"] = LabelSafe(ownerNamespace)
+	middleware.Labels[w.annotationPrefix+"/owner-name"] = LabelSafe(ownerName)
+}
+
+// Apply creates or updates a Traefik Middleware with an IPAllowList for the given HTTPRoute,
+// then patches the HTTPRoute so every rule references the Middleware via an extensionRef filter.
+//
+// The Middleware is always placed in the route's own namespace so the HTTPRoute can reference
+// it via extensionRef (which uses LocalObjectReference — no cross-namespace field).
+func (w *TraefikL7Writer) Apply(ctx context.Context, scheme *runtime.Scheme, route *gatewayApiv1.HTTPRoute, _ *gatewayApiv1.Gateway, ips, hosts, paths []string) error {
+	middleware := &TraefikMiddleware{
+		ObjectMeta: metav1.ObjectMeta{Name: route.Name, Namespace: route.Namespace},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, w.client, middleware, func() error {
+		if err := ctrl.SetControllerReference(route, middleware, scheme); err != nil {
+			return err
+		}
+		w.applyLabels(middleware, route.Namespace, route.Name)
+		middleware.Spec = TraefikMiddlewareSpec{
+			IPAllowList: &TraefikIPAllowList{SourceRange: ips},
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return w.ensureHTTPRouteFilters(ctx, route, route.Name)
+}
+
+// ensureHTTPRouteFilters adds an extensionRef filter pointing to mwName to any HTTPRoute rule
+// that doesn't already have one. It is idempotent.
+func (w *TraefikL7Writer) ensureHTTPRouteFilters(ctx context.Context, route *gatewayApiv1.HTTPRoute, mwName string) error {
+	latest := &gatewayApiv1.HTTPRoute{}
+	if err := w.client.Get(ctx, client.ObjectKeyFromObject(route), latest); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(latest.DeepCopy())
+	filter := gatewayApiv1.HTTPRouteFilter{
+		Type: gatewayApiv1.HTTPRouteFilterExtensionRef,
+		ExtensionRef: &gatewayApiv1.LocalObjectReference{
+			Group: gatewayApiv1.Group("traefik.io"),
+			Kind:  gatewayApiv1.Kind("Middleware"),
+			Name:  gatewayApiv1.ObjectName(mwName),
+		},
+	}
+	changed := false
+	for i := range latest.Spec.Rules {
+		if !hasTraefikFilter(latest.Spec.Rules[i].Filters, mwName) {
+			latest.Spec.Rules[i].Filters = append(latest.Spec.Rules[i].Filters, filter)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return w.client.Patch(ctx, latest, patch)
+}
+
+func hasTraefikFilter(filters []gatewayApiv1.HTTPRouteFilter, mwName string) bool {
+	for _, f := range filters {
+		if f.Type == gatewayApiv1.HTTPRouteFilterExtensionRef &&
+			f.ExtensionRef != nil &&
+			string(f.ExtensionRef.Group) == "traefik.io" &&
+			string(f.ExtensionRef.Kind) == "Middleware" &&
+			string(f.ExtensionRef.Name) == mwName {
+			return true
+		}
+	}
+	return false
+}
+
+// ListManaged returns all Traefik Middlewares managed by this controller.
+func (w *TraefikL7Writer) ListManaged(ctx context.Context, managedBy string) ([]client.Object, error) {
+	list := &TraefikMiddlewareList{}
+	if err := w.client.List(ctx, list, client.MatchingLabels{
+		"app.kubernetes.io/managed-by": managedBy,
+	}); err != nil {
+		return nil, err
+	}
+	result := make([]client.Object, len(list.Items))
+	for i := range list.Items {
+		result[i] = &list.Items[i]
+	}
+	return result, nil
+}
+
+// IsOrphaned reports whether the given Middleware no longer has a valid owner HTTPRoute.
+func (w *TraefikL7Writer) IsOrphaned(obj client.Object, allRoutes []gatewayApiv1.HTTPRoute) bool {
+	ownerNS := obj.GetLabels()[w.annotationPrefix+"/owner-namespace"]
+	ownerName := obj.GetLabels()[w.annotationPrefix+"/owner-name"]
+
+	for i := range allRoutes {
+		r := &allRoutes[i]
+		if r.Namespace == ownerNS && r.Name == ownerName {
+			return false
+		}
+	}
+	return true
+}
+
+// Delete removes the given Middleware from the cluster.
+func (w *TraefikL7Writer) Delete(ctx context.Context, obj client.Object) error {
+	return client.IgnoreNotFound(w.client.Delete(ctx, obj))
+}
+
+// DeleteForRoute deletes all Middlewares owned by the given route and removes the
+// extensionRef filter from the HTTPRoute's rules.
+func (w *TraefikL7Writer) DeleteForRoute(ctx context.Context, managedBy, routeNamespace, routeName string) error {
+	list := &TraefikMiddlewareList{}
+	if err := w.client.List(ctx, list, client.MatchingLabels{
+		"app.kubernetes.io/managed-by":          managedBy,
+		w.annotationPrefix + "/owner-namespace": LabelSafe(routeNamespace),
+		w.annotationPrefix + "/owner-name":      LabelSafe(routeName),
+	}); err != nil {
+		return err
+	}
+	for i := range list.Items {
+		if err := client.IgnoreNotFound(w.client.Delete(ctx, &list.Items[i])); err != nil {
+			return err
+		}
+	}
+
+	route := &gatewayApiv1.HTTPRoute{}
+	if err := w.client.Get(ctx, types.NamespacedName{Namespace: routeNamespace, Name: routeName}, route); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return w.removeHTTPRouteFilters(ctx, route, routeName)
+}
+
+func (w *TraefikL7Writer) removeHTTPRouteFilters(ctx context.Context, route *gatewayApiv1.HTTPRoute, mwName string) error {
+	patch := client.MergeFrom(route.DeepCopy())
+	changed := false
+	for i := range route.Spec.Rules {
+		kept := route.Spec.Rules[i].Filters[:0]
+		for _, f := range route.Spec.Rules[i].Filters {
+			if f.Type == gatewayApiv1.HTTPRouteFilterExtensionRef &&
+				f.ExtensionRef != nil &&
+				string(f.ExtensionRef.Group) == "traefik.io" &&
+				string(f.ExtensionRef.Kind) == "Middleware" &&
+				string(f.ExtensionRef.Name) == mwName {
+				changed = true
+				continue
+			}
+			kept = append(kept, f)
+		}
+		route.Spec.Rules[i].Filters = kept
+	}
+	if !changed {
+		return nil
+	}
+	return w.client.Patch(ctx, route, patch)
+}

--- a/pkg/controllers/writers/traefik_l7_test.go
+++ b/pkg/controllers/writers/traefik_l7_test.go
@@ -1,0 +1,268 @@
+package writers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
+)
+
+var traefikScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = gatewayApiv1.Install(s)
+	_ = AddTraefikToScheme(s)
+	_ = ipamv1alpha1.AddToScheme(s)
+	return s
+}()
+
+func newTraefikWriter(c client.Client) *TraefikL7Writer {
+	resolver := resolvers.CidrResolver{Client: c, AnnotationPrefix: resolvers.DefaultPrefix}
+	return NewTraefikL7Writer(c, "ingress-allowlisting-controller", resolver)
+}
+
+func testTraefikGateway(name, namespace string) *gatewayApiv1.Gateway {
+	return &gatewayApiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.GatewaySpec{GatewayClassName: "traefik"},
+	}
+}
+
+func testTraefikRoute(name, namespace string) *gatewayApiv1.HTTPRoute {
+	return &gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func testTraefikRouteWithRules(name, namespace string, paths ...string) *gatewayApiv1.HTTPRoute {
+	rules := make([]gatewayApiv1.HTTPRouteRule, len(paths))
+	for i, p := range paths {
+		pathType := gatewayApiv1.PathMatchPathPrefix
+		rules[i] = gatewayApiv1.HTTPRouteRule{
+			Matches: []gatewayApiv1.HTTPRouteMatch{
+				{Path: &gatewayApiv1.HTTPPathMatch{Type: &pathType, Value: &p}},
+			},
+		}
+	}
+	return &gatewayApiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       gatewayApiv1.HTTPRouteSpec{Rules: rules},
+	}
+}
+
+// TestTraefikL7Writer_Apply_SameNamespace verifies a Middleware is created in the route's namespace.
+func TestTraefikL7Writer_Apply_SameNamespace(t *testing.T) {
+	route := testTraefikRoute("my-route", "mynamespace")
+	gw := testTraefikGateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+	w := newTraefikWriter(k8sClient)
+
+	err := w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil)
+	assert.NoError(t, err)
+
+	mw := &TraefikMiddleware{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, mw)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.0/8"}, mw.Spec.IPAllowList.SourceRange)
+	assert.Equal(t, "ingress-allowlisting-controller", mw.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "mynamespace", mw.Labels["ipam.adevinta.com/owner-namespace"])
+	assert.Equal(t, "my-route", mw.Labels["ipam.adevinta.com/owner-name"])
+}
+
+// TestTraefikL7Writer_Apply_CrossNamespace verifies a Middleware is always placed in the route's
+// own namespace regardless of gateway namespace, so the HTTPRoute extensionRef can reach it.
+func TestTraefikL7Writer_Apply_CrossNamespace(t *testing.T) {
+	route := testTraefikRoute("my-route", "app-ns")
+	gw := testTraefikGateway("my-gateway", "gw-ns")
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+	w := newTraefikWriter(k8sClient)
+
+	err := w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil)
+	assert.NoError(t, err)
+
+	// Middleware must be in route namespace (app-ns), not gateway namespace (gw-ns).
+	mw := &TraefikMiddleware{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "app-ns"}, mw)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.0/8"}, mw.Spec.IPAllowList.SourceRange)
+}
+
+// TestTraefikL7Writer_Apply_PathsIgnored verifies that paths have no effect on the Middleware name or spec.
+func TestTraefikL7Writer_Apply_PathsIgnored(t *testing.T) {
+	route := testTraefikRoute("my-route", "mynamespace")
+	gw := testTraefikGateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+	w := newTraefikWriter(k8sClient)
+
+	err := w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, []string{"/admin/*"})
+	assert.NoError(t, err)
+
+	// Name is still just route name — no path suffix for Traefik
+	mw := &TraefikMiddleware{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, mw)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.0/8"}, mw.Spec.IPAllowList.SourceRange)
+}
+
+// TestTraefikL7Writer_Apply_OwnerRef verifies owner reference is always set (same or cross namespace).
+func TestTraefikL7Writer_Apply_OwnerRef(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		routeNS   string
+		gatewayNS string
+	}{
+		{"same-namespace", "mynamespace", "mynamespace"},
+		{"cross-namespace", "app-ns", "gw-ns"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			route := testTraefikRoute("my-route", tc.routeNS)
+			gw := testTraefikGateway("my-gateway", tc.gatewayNS)
+			k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+			w := newTraefikWriter(k8sClient)
+
+			err := w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil)
+			assert.NoError(t, err)
+
+			mw := &TraefikMiddleware{}
+			err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: tc.routeNS}, mw)
+			assert.NoError(t, err)
+			assert.Len(t, mw.OwnerReferences, 1)
+			assert.Equal(t, "my-route", mw.OwnerReferences[0].Name)
+		})
+	}
+}
+
+// TestTraefikL7Writer_Apply_InjectsFilters verifies that Apply patches every HTTPRoute rule
+// with an extensionRef filter pointing to the Middleware.
+func TestTraefikL7Writer_Apply_InjectsFilters(t *testing.T) {
+	route := testTraefikRouteWithRules("my-route", "mynamespace", "/api", "/health")
+	gw := testTraefikGateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+	w := newTraefikWriter(k8sClient)
+
+	err := w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil)
+	assert.NoError(t, err)
+
+	updated := &gatewayApiv1.HTTPRoute{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, updated)
+	assert.NoError(t, err)
+	assert.Len(t, updated.Spec.Rules, 2, "rule count must be preserved")
+	for i, rule := range updated.Spec.Rules {
+		assert.True(t, hasTraefikFilter(rule.Filters, "my-route"),
+			"rule %d must have extensionRef filter", i)
+	}
+}
+
+// TestTraefikL7Writer_Apply_InjectsFilters_Idempotent verifies a second Apply does not duplicate filters.
+func TestTraefikL7Writer_Apply_InjectsFilters_Idempotent(t *testing.T) {
+	route := testTraefikRouteWithRules("my-route", "mynamespace", "/api")
+	gw := testTraefikGateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+	w := newTraefikWriter(k8sClient)
+
+	assert.NoError(t, w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil))
+	assert.NoError(t, w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil))
+
+	updated := &gatewayApiv1.HTTPRoute{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, updated)
+	assert.NoError(t, err)
+
+	count := 0
+	for _, f := range updated.Spec.Rules[0].Filters {
+		if f.Type == gatewayApiv1.HTTPRouteFilterExtensionRef {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "extensionRef filter must not be duplicated")
+}
+
+// TestTraefikL7Writer_DeleteForRoute_RemovesFilters verifies that DeleteForRoute also removes
+// the extensionRef filter from the HTTPRoute's rules.
+func TestTraefikL7Writer_DeleteForRoute_RemovesFilters(t *testing.T) {
+	route := testTraefikRouteWithRules("my-route", "mynamespace", "/api")
+	gw := testTraefikGateway("my-gateway", "mynamespace")
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(route).Build()
+	w := newTraefikWriter(k8sClient)
+
+	// First apply so the filter and Middleware exist.
+	assert.NoError(t, w.Apply(context.Background(), traefikScheme, route, gw, []string{"10.0.0.0/8"}, nil, nil))
+
+	// Confirm filter was added.
+	before := &gatewayApiv1.HTTPRoute{}
+	assert.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, before))
+	assert.True(t, hasTraefikFilter(before.Spec.Rules[0].Filters, "my-route"))
+
+	// Now delete.
+	assert.NoError(t, w.DeleteForRoute(context.Background(), "ingress-allowlisting-controller", "mynamespace", "my-route"))
+
+	// Middleware gone.
+	mw := &TraefikMiddleware{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, mw)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "Middleware should be gone")
+
+	// Filter removed.
+	after := &gatewayApiv1.HTTPRoute{}
+	assert.NoError(t, k8sClient.Get(context.Background(), client.ObjectKey{Name: "my-route", Namespace: "mynamespace"}, after))
+	assert.False(t, hasTraefikFilter(after.Spec.Rules[0].Filters, "my-route"), "extensionRef filter must be removed")
+}
+
+// TestTraefikL7Writer_ListManaged verifies only managed Middlewares are returned.
+func TestTraefikL7Writer_ListManaged(t *testing.T) {
+	managed := &TraefikMiddleware{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "managed", Namespace: "mynamespace",
+			Labels: map[string]string{"app.kubernetes.io/managed-by": "ingress-allowlisting-controller"},
+		},
+	}
+	unmanaged := &TraefikMiddleware{
+		ObjectMeta: metav1.ObjectMeta{Name: "unmanaged", Namespace: "mynamespace"},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).WithObjects(managed, unmanaged).Build()
+	w := newTraefikWriter(k8sClient)
+
+	objs, err := w.ListManaged(context.Background(), "ingress-allowlisting-controller")
+	assert.NoError(t, err)
+	assert.Len(t, objs, 1)
+	assert.Equal(t, "managed", objs[0].GetName())
+}
+
+// TestTraefikL7Writer_IsOrphaned verifies orphan detection by owner labels.
+func TestTraefikL7Writer_IsOrphaned(t *testing.T) {
+	mw := &TraefikMiddleware{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-route", Namespace: "mynamespace",
+			Labels: map[string]string{
+				"ipam.adevinta.com/owner-namespace": "mynamespace",
+				"ipam.adevinta.com/owner-name":      "my-route",
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).Build()
+	w := newTraefikWriter(k8sClient)
+
+	existingRoute := gatewayApiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "mynamespace"}}
+	deletedRoute := gatewayApiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "other-route", Namespace: "mynamespace"}}
+
+	assert.False(t, w.IsOrphaned(mw, []gatewayApiv1.HTTPRoute{existingRoute}), "should not be orphaned when owner route exists")
+	assert.True(t, w.IsOrphaned(mw, []gatewayApiv1.HTTPRoute{deletedRoute}), "should be orphaned when owner route is gone")
+	assert.True(t, w.IsOrphaned(mw, []gatewayApiv1.HTTPRoute{}), "should be orphaned when no routes exist")
+}
+
+// TestTraefikL7Writer_DoesNotImplementMerge verifies TraefikL7Writer does not satisfy MergeableL7PolicyWriter.
+func TestTraefikL7Writer_DoesNotImplementMerge(t *testing.T) {
+	k8sClient := fake.NewClientBuilder().WithScheme(traefikScheme).Build()
+	w := newTraefikWriter(k8sClient)
+
+	var iface L7PolicyWriter = w
+	_, ok := iface.(MergeableL7PolicyWriter)
+	assert.False(t, ok, "TraefikL7Writer must not implement MergeableL7PolicyWriter")
+}

--- a/pkg/controllers/writers/traefik_types.go
+++ b/pkg/controllers/writers/traefik_types.go
@@ -1,0 +1,72 @@
+package writers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	TraefikSchemeGroupVersion = schema.GroupVersion{Group: "traefik.io", Version: "v1alpha1"}
+	TraefikSchemeBuilder      = runtime.NewSchemeBuilder(addTraefikTypes)
+	AddTraefikToScheme        = TraefikSchemeBuilder.AddToScheme
+)
+
+func addTraefikTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(TraefikSchemeGroupVersion.WithKind("Middleware"), &TraefikMiddleware{})
+	scheme.AddKnownTypeWithName(TraefikSchemeGroupVersion.WithKind("MiddlewareList"), &TraefikMiddlewareList{})
+	metav1.AddToGroupVersion(scheme, TraefikSchemeGroupVersion)
+	return nil
+}
+
+// TraefikMiddleware is a minimal representation of the Traefik Middleware CRD.
+// +kubebuilder:object:root=true
+type TraefikMiddleware struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              TraefikMiddlewareSpec `json:"spec,omitempty"`
+}
+
+func (in *TraefikMiddleware) DeepCopyObject() runtime.Object {
+	out := new(TraefikMiddleware)
+	*out = *in
+	out.Spec = in.Spec.deepCopy()
+	return out
+}
+
+// TraefikMiddlewareList contains a list of TraefikMiddleware.
+// +kubebuilder:object:root=true
+type TraefikMiddlewareList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []TraefikMiddleware `json:"items"`
+}
+
+func (in *TraefikMiddlewareList) DeepCopyObject() runtime.Object {
+	out := new(TraefikMiddlewareList)
+	*out = *in
+	out.Items = make([]TraefikMiddleware, len(in.Items))
+	for i := range in.Items {
+		out.Items[i] = *in.Items[i].DeepCopyObject().(*TraefikMiddleware)
+	}
+	return out
+}
+
+// TraefikMiddlewareSpec holds the relevant subset of Traefik MiddlewareSpec fields.
+type TraefikMiddlewareSpec struct {
+	IPAllowList *TraefikIPAllowList `json:"ipAllowList,omitempty"`
+}
+
+func (s TraefikMiddlewareSpec) deepCopy() TraefikMiddlewareSpec {
+	if s.IPAllowList == nil {
+		return s
+	}
+	ranges := make([]string, len(s.IPAllowList.SourceRange))
+	copy(ranges, s.IPAllowList.SourceRange)
+	return TraefikMiddlewareSpec{IPAllowList: &TraefikIPAllowList{SourceRange: ranges}}
+}
+
+// TraefikIPAllowList holds the IP allowlist configuration.
+type TraefikIPAllowList struct {
+	SourceRange []string `json:"sourceRange,omitempty"`
+}

--- a/pkg/controllers/writers/traefik_types.go
+++ b/pkg/controllers/writers/traefik_types.go
@@ -20,7 +20,6 @@ func addTraefikTypes(scheme *runtime.Scheme) error {
 }
 
 // TraefikMiddleware is a minimal representation of the Traefik Middleware CRD.
-// +kubebuilder:object:root=true
 type TraefikMiddleware struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -35,7 +34,6 @@ func (in *TraefikMiddleware) DeepCopyObject() runtime.Object {
 }
 
 // TraefikMiddlewareList contains a list of TraefikMiddleware.
-// +kubebuilder:object:root=true
 type TraefikMiddlewareList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
New features:

* adding `--ingress-support-enabled` (default `true`) so no behaviour changed, but we can disable it when ingress is not needed anymore
  
* traefik support - only `kind: middleware` per `httproute` (no native gateway support)
   (we could think about supporting gateway in this controller by merging gtw CIDRs with HTTProute CIDRs)

* Autodetection:
* * `isCRDInstalled(mapper, group, version, kind) bool` - new helper in `controllers.go` that checks the REST mapper at startup. No error = CRD exists on the cluster.

* * `BuildWriterRegistries` - now takes a `meta.RESTMapper` and only registers Istio/Traefik writers when their CRDs are present. User might have combination of both installed.

* * `SetupControllersWithManager` — uses `mgr.GetRESTMapper()` to call `BuildWriterRegistries` (replaces the hardcoded writer list).

* * `GatewayAllowlistingReconciler.SetupWithManager` and `HTTPRouteAllowlistingReconciler.SetupWithManager` - both check `isCRDInstalled` before calling
  `Owns(&istiosecurityv1.AuthorizationPolicy{})`.

* * `main.go` - creates a `DynamicRESTMapper` from `restConfig` before the manager starts, passes it to `BuildWriterRegistries`.

Result: controller auto-detects on startup and works on any combination - Istio-only, Traefik-only, or both.
Also useful when we gonna add more HTTPRoute backends support in the future.