### PR TITLE
fix(RBAC): correct +kubebuilder markers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,9 +5,20 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - gatewayclasses
   - gateways
+  - httproutes
   verbs:
   - get
   - list
@@ -28,7 +39,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   - networkpolicies
@@ -41,7 +52,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses/status
   verbs:

--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -38,6 +38,7 @@ type CIDRReconciler struct {
 	CIDRsList ipamv1alpha1.CIDRsGetterList
 }
 
+// +kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ipam.adevinta.com,resources=clustercidrs,verbs=get;list;watch;create;update;patch;delete
 

--- a/pkg/controllers/ingress_controller.go
+++ b/pkg/controllers/ingress_controller.go
@@ -28,8 +28,8 @@ type IngressReconciler struct {
 	CidrResolver       resolvers.CidrResolver
 }
 
-// +kubebuilder:rbac:groups=networking,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking,resources=ingresses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=get;update;patch
 
 func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.DefaultLogger.WithContext(ctx).WithField("ingress", req.NamespacedName)
@@ -85,8 +85,8 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, ingressMeta ne
 	return ingressMeta, nil
 }
 
-// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=clustercidrs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=clustercidrs,verbs=get;list;watch
 
 func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
 	var ing client.Object = &netv1.Ingress{}

--- a/pkg/controllers/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy_controller.go
@@ -31,7 +31,6 @@ type NetworkPolicyReconciler struct {
 var ErrMultipleRulesNotSupported = errors.New("Networkpolicy with multiple egress or ingress rules is not supported")
 
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
 
 func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.DefaultLogger.WithContext(ctx).WithField("networkpolicy", req.NamespacedName)
@@ -132,8 +131,7 @@ func (r *NetworkPolicyReconciler) reconcileNetworkPolicy(ctx context.Context, ne
 	return networkPolicy, nil
 }
 
-// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs,verbs=get;list;watch
-// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=clustercidrs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.adevinta.com,resources=cidrs;clustercidrs,verbs=get;list;watch
 
 func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) error {
 	build := ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
Tunning the kubebuilder markers so the `make manifests` coudl generate a proper role file