### PR TITLE
fix(controller-gen): separate crds (narrow) from rbac to eliminate empty crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ deploy: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./pkg/apis/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." output:rbac:artifacts:config=config/rbac output:webhook:artifacts:config=config/webhook
 
 # Verify that the committed manifests match the kubebuilder markers.
 verify-manifests: manifests


### PR DESCRIPTION
fix builds like
https://github.com/adevinta/ingress-allowlisting-controller/actions/runs/32717075668/job/97400488519