### PR TITLE
feat(flag): stop watching configmaps and secrets

### DIFF
--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -59,6 +59,7 @@ func main() {
 	var httpRouteLabelSelector string
 	var as string
 	var annotationPrefix string
+	var watchConfigmapSecrets bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -70,6 +71,7 @@ func main() {
 	flag.StringVar(&legacyGroupVersion, "legacy-group-version", "", "Enables coexistence of two CRDS with different groups for CIDR objects.")
 	flag.StringVar(&as, "as", "", "The user to impersonate to run this controller")
 	flag.StringVar(&annotationPrefix, "annotation-prefix", "ipam.adevinta.com", "Enables coexistence of two CRDS with different groups for CIDR objects.")
+	flag.BoolVar(&watchConfigmapSecrets, "watch-configmap-secrets", true, "Watch ConfigMaps and Secrets to trigger CIDR reconciliation on changes. Disable if not using configmap/secret HTTP header sources to reduce API server load.")
 	flag.Parse()
 	ctrl.SetLogger(log.NewLogr(log.DefaultLogger))
 
@@ -87,7 +89,7 @@ func main() {
 
 	// nil client is fine here — writers are only used to call RequiredPermissions(), not for K8s ops.
 	l4Writers, l7Writers := controllers.BuildWriterRegistries(nil, "preflight", annotationPrefix)
-	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, l4Writers, l7Writers)
+	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, watchConfigmapSecrets, l4Writers, l7Writers)
 
 	mgrOptions := ctrl.Options{
 		Scheme: scheme,
@@ -115,7 +117,7 @@ func main() {
 		setupLog.Fatal(err, "unable to start manager")
 	}
 
-	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix); err != nil {
+	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix, watchConfigmapSecrets); err != nil {
 		setupLog.Fatal(err, "unable to setup controllers")
 	}
 
@@ -126,18 +128,21 @@ func main() {
 	}
 }
 
-func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {
+func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled, watchConfigmapSecrets bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {
 	cs := kubernetes.NewForConfigOrDie(restConfig)
 
 	var perms []writers.Permission
 
-	// Always required — CIDRs and secret/configmap sources used by all controllers.
 	perms = append(perms,
 		writers.Permission{Group: "ipam.adevinta.com", Resource: "cidrs", Verb: "get"},
 		writers.Permission{Group: "ipam.adevinta.com", Resource: "clustercidrs", Verb: "get"},
-		writers.Permission{Group: "", Resource: "secrets", Verb: "get"},
-		writers.Permission{Group: "", Resource: "configmaps", Verb: "get"},
 	)
+	if watchConfigmapSecrets {
+		perms = append(perms,
+			writers.Permission{Group: "", Resource: "secrets", Verb: "get"},
+			writers.Permission{Group: "", Resource: "configmaps", Verb: "get"},
+		)
+	}
 
 	if gatewayEnabled {
 		perms = append(perms,

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -57,6 +58,7 @@ func main() {
 	var networkPolicySupportEnabled bool
 	var httpRouteSupportEnabled bool
 	var httpRouteLabelSelector string
+	var secretLabelSelector string
 	var as string
 	var annotationPrefix string
 	var httpHeadersEnabled bool
@@ -68,6 +70,7 @@ func main() {
 	flag.BoolVar(&networkPolicySupportEnabled, "networkpolicy-support-enabled", false, "Enable networkpolicy support for the controller")
 	flag.BoolVar(&httpRouteSupportEnabled, "httproute-support-enabled", false, "Enable HTTPRoute support for the controller")
 	flag.StringVar(&httpRouteLabelSelector, "httproute-label-selector", "", "Label selector to filter HTTPRoutes watched by the controller (e.g. 'app.kubernetes.io/managed-by=my-team'). Restricts the informer cache at the API server level.")
+	flag.StringVar(&secretLabelSelector, "secret-label-selector", "", "Label selector to restrict which Secrets and ConfigMaps are cached as HTTP header sources (e.g. 'ipam.adevinta.com/cidr-header-source=true'). Only effective when --http-headers-enabled=true.")
 	flag.StringVar(&legacyGroupVersion, "legacy-group-version", "", "Enables coexistence of two CRDS with different groups for CIDR objects.")
 	flag.StringVar(&as, "as", "", "The user to impersonate to run this controller")
 	flag.StringVar(&annotationPrefix, "annotation-prefix", "ipam.adevinta.com", "Enables coexistence of two CRDS with different groups for CIDR objects.")
@@ -100,17 +103,26 @@ func main() {
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "c72663fe.github.com/adevinta/ingress-allowlisting-controller",
 	}
+	byObject := map[client.Object]cache.ByObject{}
 	if httpRouteSupportEnabled && httpRouteLabelSelector != "" {
 		selector, err := labels.Parse(httpRouteLabelSelector)
 		if err != nil {
 			setupLog.Fatal(err, "invalid --httproute-label-selector")
 		}
-		mgrOptions.Cache = cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&gatewayApiv1.HTTPRoute{}: {Label: selector},
-			},
-		}
+		byObject[&gatewayApiv1.HTTPRoute{}] = cache.ByObject{Label: selector}
 		setupLog.Infof("HTTPRoute informer cache restricted to label selector: %s", httpRouteLabelSelector)
+	}
+	if httpHeadersEnabled && secretLabelSelector != "" {
+		selector, err := labels.Parse(secretLabelSelector)
+		if err != nil {
+			setupLog.Fatal(err, "invalid --secret-label-selector")
+		}
+		byObject[&corev1.Secret{}] = cache.ByObject{Label: selector}
+		byObject[&corev1.ConfigMap{}] = cache.ByObject{Label: selector}
+		setupLog.Infof("Secret/ConfigMap informer cache restricted to label selector: %s", secretLabelSelector)
+	}
+	if len(byObject) > 0 {
+		mgrOptions.Cache = cache.Options{ByObject: byObject}
 	}
 	mgr, err := ctrl.NewManager(restConfig, mgrOptions)
 	if err != nil {

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -59,7 +59,7 @@ func main() {
 	var httpRouteLabelSelector string
 	var as string
 	var annotationPrefix string
-	var watchConfigmapSecrets bool
+	var httpHeadersEnabled bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -71,7 +71,7 @@ func main() {
 	flag.StringVar(&legacyGroupVersion, "legacy-group-version", "", "Enables coexistence of two CRDS with different groups for CIDR objects.")
 	flag.StringVar(&as, "as", "", "The user to impersonate to run this controller")
 	flag.StringVar(&annotationPrefix, "annotation-prefix", "ipam.adevinta.com", "Enables coexistence of two CRDS with different groups for CIDR objects.")
-	flag.BoolVar(&watchConfigmapSecrets, "watch-configmap-secrets", true, "Watch ConfigMaps and Secrets to trigger CIDR reconciliation on changes. Disable if not using configmap/secret HTTP header sources to reduce API server load.")
+	flag.BoolVar(&httpHeadersEnabled, "http-headers-enabled", true, "Enable reading Secrets and ConfigMaps as HTTP header sources for CIDR URL fetches. Disabling removes secret/configmap access entirely and skips reactive re-reconciliation on their changes.")
 	flag.Parse()
 	ctrl.SetLogger(log.NewLogr(log.DefaultLogger))
 
@@ -89,7 +89,7 @@ func main() {
 
 	// nil client is fine here — writers are only used to call RequiredPermissions(), not for K8s ops.
 	l4Writers, l7Writers := controllers.BuildWriterRegistries(nil, "preflight", annotationPrefix)
-	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, watchConfigmapSecrets, l4Writers, l7Writers)
+	checkRBAC(restConfig, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, httpHeadersEnabled, l4Writers, l7Writers)
 
 	mgrOptions := ctrl.Options{
 		Scheme: scheme,
@@ -117,7 +117,7 @@ func main() {
 		setupLog.Fatal(err, "unable to start manager")
 	}
 
-	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix, watchConfigmapSecrets); err != nil {
+	if err = controllers.SetupControllersWithManager(mgr, gatewaySupportEnabled, networkPolicySupportEnabled, httpRouteSupportEnabled, legacyGroupVersion, "", annotationPrefix, httpHeadersEnabled); err != nil {
 		setupLog.Fatal(err, "unable to setup controllers")
 	}
 
@@ -128,7 +128,7 @@ func main() {
 	}
 }
 
-func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled, watchConfigmapSecrets bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {
+func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled, httpHeadersEnabled bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {
 	cs := kubernetes.NewForConfigOrDie(restConfig)
 
 	var perms []writers.Permission
@@ -137,7 +137,7 @@ func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, ht
 		writers.Permission{Group: "ipam.adevinta.com", Resource: "cidrs", Verb: "get"},
 		writers.Permission{Group: "ipam.adevinta.com", Resource: "clustercidrs", Verb: "get"},
 	)
-	if watchConfigmapSecrets {
+	if httpHeadersEnabled {
 		perms = append(perms,
 			writers.Permission{Group: "", Resource: "secrets", Verb: "get"},
 			writers.Permission{Group: "", Resource: "configmaps", Verb: "get"},

--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
 {{- with .Values.annotationPrefix }}
         - "--annotation-prefix={{ . }}"
 {{- end }}
-{{- if not .Values.watchConfigmapSecrets }}
-        - "--watch-configmap-secrets=false"
+{{- if not .Values.httpHeadersEnabled }}
+        - "--http-headers-enabled=false"
 {{- end }}
         ports:
         - containerPort: 8080

--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
 {{- with .Values.annotationPrefix }}
         - "--annotation-prefix={{ . }}"
 {{- end }}
+{{- if not .Values.watchConfigmapSecrets }}
+        - "--watch-configmap-secrets=false"
+{{- end }}
         ports:
         - containerPort: 8080
         resources:

--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
 {{- if not .Values.httpHeadersEnabled }}
         - "--http-headers-enabled=false"
 {{- end }}
+{{- if and .Values.httpHeadersEnabled .Values.secretLabelSelector }}
+        - "--secret-label-selector={{ .Values.secretLabelSelector }}"
+{{- end }}
         ports:
         - containerPort: 8080
         resources:

--- a/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
@@ -30,9 +30,11 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["list","get", "update", "create", "watch"]
+{{- if .Values.watchConfigmapSecrets }}
 - apiGroups: [""]
   resources: ["secrets", "configmaps"]
   verbs: ["get", "watch", "list"]
+{{- end }}
 {{- if .Values.gateway.enabled }}
 - apiGroups: ["gateway.networking.k8s.io"]
   resources: ["gateways", "gatewayclasses"]

--- a/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/rbac.yaml
@@ -30,7 +30,7 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["list","get", "update", "create", "watch"]
-{{- if .Values.watchConfigmapSecrets }}
+{{- if .Values.httpHeadersEnabled }}
 - apiGroups: [""]
   resources: ["secrets", "configmaps"]
   verbs: ["get", "watch", "list"]

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -43,3 +43,4 @@ tolerations: []
 # legacyGroupVersion: "ipam.legacy.com/v1alpha1"
 legacyGroupVersion: ""
 annotationPrefix: "ipam.adevinta.com"
+watchConfigmapSecrets: true

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -43,4 +43,4 @@ tolerations: []
 # legacyGroupVersion: "ipam.legacy.com/v1alpha1"
 legacyGroupVersion: ""
 annotationPrefix: "ipam.adevinta.com"
-watchConfigmapSecrets: true
+httpHeadersEnabled: true

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -44,3 +44,4 @@ tolerations: []
 legacyGroupVersion: ""
 annotationPrefix: "ipam.adevinta.com"
 httpHeadersEnabled: true
+secretLabelSelector: ""

--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -34,8 +34,9 @@ var ipv4RegExp = regexp.MustCompile(`^\d{1,3}\.\d{1,3}\.\d{1,3}.\d{1,3}$`)
 
 type CIDRReconciler struct {
 	client.Client
-	CIDRs     ipamv1alpha1.CIDRsGetter
-	CIDRsList ipamv1alpha1.CIDRsGetterList
+	CIDRs                ipamv1alpha1.CIDRsGetter
+	CIDRsList            ipamv1alpha1.CIDRsGetterList
+	WatchConfigmapSecrets bool
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list;watch
@@ -455,26 +456,28 @@ func (r *CIDRReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) e
 		build = build.Named(fmt.Sprintf("%T", r.CIDRs))
 	}
 	build = build.For(r.CIDRs)
-	build = build.Watches(
-		&v1.Secret{},
-		handler.EnqueueRequestsFromMapFunc(
-			newObjectRefToCIDRsFuncMap(
-				r.Client,
-				r.CIDRsList,
-				secretSource,
+	if r.WatchConfigmapSecrets {
+		build = build.Watches(
+			&v1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(
+				newObjectRefToCIDRsFuncMap(
+					r.Client,
+					r.CIDRsList,
+					secretSource,
+				),
 			),
-		),
-	)
-	build = build.Watches(
-		&v1.ConfigMap{},
-		handler.EnqueueRequestsFromMapFunc(
-			newObjectRefToCIDRsFuncMap(
-				r.Client,
-				r.CIDRsList,
-				configMapSource,
+		)
+		build = build.Watches(
+			&v1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(
+				newObjectRefToCIDRsFuncMap(
+					r.Client,
+					r.CIDRsList,
+					configMapSource,
+				),
 			),
-		),
-	)
+		)
+	}
 	return build.Complete(r)
 }
 

--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -36,7 +36,7 @@ type CIDRReconciler struct {
 	client.Client
 	CIDRs                ipamv1alpha1.CIDRsGetter
 	CIDRsList            ipamv1alpha1.CIDRsGetterList
-	WatchConfigmapSecrets bool
+	HTTPHeadersEnabled bool
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list;watch
@@ -372,9 +372,11 @@ func (r *CIDRReconciler) addHTTPSource(ctx context.Context, cidrs ipamv1alpha1.C
 	if err != nil {
 		return err
 	}
-	err = r.updateClientHeaders(ctx, cidrs.GetNamespace(), req.Header, spec.CIDRsSource.Location.HeadersFrom)
-	if err != nil {
-		return err
+	if r.HTTPHeadersEnabled {
+		err = r.updateClientHeaders(ctx, cidrs.GetNamespace(), req.Header, spec.CIDRsSource.Location.HeadersFrom)
+		if err != nil {
+			return err
+		}
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -456,7 +458,7 @@ func (r *CIDRReconciler) SetupWithManager(mgr ctrl.Manager, namePrefix string) e
 		build = build.Named(fmt.Sprintf("%T", r.CIDRs))
 	}
 	build = build.For(r.CIDRs)
-	if r.WatchConfigmapSecrets {
+	if r.HTTPHeadersEnabled {
 		build = build.Watches(
 			&v1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(

--- a/pkg/controllers/cidrs_controller_test.go
+++ b/pkg/controllers/cidrs_controller_test.go
@@ -376,9 +376,10 @@ func TestCIDRsReconcileFromHTTP(t *testing.T) {
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cidrs, secret).WithStatusSubresource(cidrs).Build()
 	reconciler := &CIDRReconciler{
-		CIDRs:     &ipamv1alpha1.CIDRs{},
-		CIDRsList: &ipamv1alpha1.CIDRsList{},
-		Client:    fakeClient,
+		CIDRs:              &ipamv1alpha1.CIDRs{},
+		CIDRsList:          &ipamv1alpha1.CIDRsList{},
+		Client:             fakeClient,
+		HTTPHeadersEnabled: true,
 	}
 
 	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cidrs)})
@@ -870,6 +871,53 @@ func TestCIDRsReconcileFromHTTPWhenGetFails(t *testing.T) {
 	assert.Equal(t, v1.ConditionFalse, cidrs.GetStatus().Conditions[0].Status)
 	assert.Contains(t, cidrs.GetStatus().Conditions[0].Message, "Failed to get CIDRs from http source")
 	assert.Contains(t, cidrs.GetStatus().Conditions[0].Message, "403")
+}
+
+func TestCIDRsReconcileFromHTTPDoesNotReadSecretsWhenHeadersDisabled(t *testing.T) {
+	ctx := context.TODO()
+	testNamespaceName := "mynamespace"
+	scheme, err := Scheme("")
+	require.NoError(t, err)
+
+	headersReceived := http.Header{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headersReceived = r.Header
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`["10.0.0.0/8"]`))
+	}))
+	defer server.Close()
+
+	cidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-net", Namespace: testNamespaceName},
+		Spec: ipamv1alpha1.CIDRsSpec{CIDRsSource: ipamv1alpha1.CIDRsSource{
+			Location: ipamv1alpha1.CIDRsLocation{
+				URI: server.URL,
+				HeadersFrom: []ipamv1alpha1.HeadersFrom{
+					{SecretRef: ipamv1alpha1.ObjectRef{Name: "my-secret"}},
+				},
+			},
+		}},
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: testNamespaceName},
+		Data:       map[string][]byte{"Authorization": []byte("Bearer secret-token")},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cidrs, secret).WithStatusSubresource(cidrs).Build()
+	reconciler := &CIDRReconciler{
+		CIDRs:              &ipamv1alpha1.CIDRs{},
+		CIDRsList:          &ipamv1alpha1.CIDRsList{},
+		Client:             fakeClient,
+		HTTPHeadersEnabled: false,
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cidrs)})
+	require.NoError(t, err)
+	require.Equal(t, result, reconcile.Result{})
+
+	assert.Empty(t, headersReceived.Get("Authorization"), "secret headers must not be sent when HTTPHeadersEnabled=false")
+
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(cidrs), cidrs))
+	assert.Equal(t, []string{"10.0.0.0/8"}, cidrs.GetStatus().CIDRs)
 }
 
 func TestUpdateClientHeaders(t *testing.T) {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -43,7 +43,7 @@ func BuildWriterRegistries(c client.Client, managedBy, annotationPrefix string) 
 	return l4, l7
 }
 
-func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string) error {
+func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string, watchConfigmapSecrets bool) error {
 	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: mgr.GetClient()}
 
 	if err := (&IngressReconciler{
@@ -56,32 +56,36 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 	}
 
 	if err := (&CIDRReconciler{
-		Client:    mgr.GetClient(),
-		CIDRs:     &ipamv1alpha1.CIDRs{},
-		CIDRsList: &ipamv1alpha1.CIDRsList{},
+		Client:               mgr.GetClient(),
+		CIDRs:                &ipamv1alpha1.CIDRs{},
+		CIDRsList:            &ipamv1alpha1.CIDRsList{},
+		WatchConfigmapSecrets: watchConfigmapSecrets,
 	}).SetupWithManager(mgr, namePrefix); err != nil {
 		return &setupError{error: err, controllerType: "CIDRs"}
 	}
 	if err := (&CIDRReconciler{
-		Client:    mgr.GetClient(),
-		CIDRs:     &ipamv1alpha1.ClusterCIDRs{},
-		CIDRsList: &ipamv1alpha1.ClusterCIDRsList{},
+		Client:               mgr.GetClient(),
+		CIDRs:                &ipamv1alpha1.ClusterCIDRs{},
+		CIDRsList:            &ipamv1alpha1.ClusterCIDRsList{},
+		WatchConfigmapSecrets: watchConfigmapSecrets,
 	}).SetupWithManager(mgr, namePrefix); err != nil {
 		return &setupError{error: err, controllerType: "ClusterCIDRs"}
 	}
 
 	if legacyGroupVersion != "" {
 		if err := (&CIDRReconciler{
-			Client:    mgr.GetClient(),
-			CIDRs:     &ipamv1alpha1_legacy.CIDRs{},
-			CIDRsList: &ipamv1alpha1_legacy.CIDRsList{},
+			Client:               mgr.GetClient(),
+			CIDRs:                &ipamv1alpha1_legacy.CIDRs{},
+			CIDRsList:            &ipamv1alpha1_legacy.CIDRsList{},
+			WatchConfigmapSecrets: watchConfigmapSecrets,
 		}).SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "LegacyCIDRs"}
 		}
 		if err := (&CIDRReconciler{
-			Client:    mgr.GetClient(),
-			CIDRs:     &ipamv1alpha1_legacy.ClusterCIDRs{},
-			CIDRsList: &ipamv1alpha1_legacy.ClusterCIDRsList{},
+			Client:               mgr.GetClient(),
+			CIDRs:                &ipamv1alpha1_legacy.ClusterCIDRs{},
+			CIDRsList:            &ipamv1alpha1_legacy.ClusterCIDRsList{},
+			WatchConfigmapSecrets: watchConfigmapSecrets,
 		}).SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "LegacyClusterCIDRs"}
 		}

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -43,7 +43,7 @@ func BuildWriterRegistries(c client.Client, managedBy, annotationPrefix string) 
 	return l4, l7
 }
 
-func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string, watchConfigmapSecrets bool) error {
+func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, networkPolicySupportEnabled bool, httpRouteSupportEnabled bool, legacyGroupVersion, namePrefix string, annotationPrefix string, httpHeadersEnabled bool) error {
 	cidrResolver := resolvers.CidrResolver{AnnotationPrefix: annotationPrefix, Client: mgr.GetClient()}
 
 	if err := (&IngressReconciler{
@@ -56,36 +56,36 @@ func SetupControllersWithManager(mgr ctrl.Manager, gatewaySupportEnabled bool, n
 	}
 
 	if err := (&CIDRReconciler{
-		Client:               mgr.GetClient(),
-		CIDRs:                &ipamv1alpha1.CIDRs{},
-		CIDRsList:            &ipamv1alpha1.CIDRsList{},
-		WatchConfigmapSecrets: watchConfigmapSecrets,
+		Client:             mgr.GetClient(),
+		CIDRs:              &ipamv1alpha1.CIDRs{},
+		CIDRsList:          &ipamv1alpha1.CIDRsList{},
+		HTTPHeadersEnabled: httpHeadersEnabled,
 	}).SetupWithManager(mgr, namePrefix); err != nil {
 		return &setupError{error: err, controllerType: "CIDRs"}
 	}
 	if err := (&CIDRReconciler{
-		Client:               mgr.GetClient(),
-		CIDRs:                &ipamv1alpha1.ClusterCIDRs{},
-		CIDRsList:            &ipamv1alpha1.ClusterCIDRsList{},
-		WatchConfigmapSecrets: watchConfigmapSecrets,
+		Client:             mgr.GetClient(),
+		CIDRs:              &ipamv1alpha1.ClusterCIDRs{},
+		CIDRsList:          &ipamv1alpha1.ClusterCIDRsList{},
+		HTTPHeadersEnabled: httpHeadersEnabled,
 	}).SetupWithManager(mgr, namePrefix); err != nil {
 		return &setupError{error: err, controllerType: "ClusterCIDRs"}
 	}
 
 	if legacyGroupVersion != "" {
 		if err := (&CIDRReconciler{
-			Client:               mgr.GetClient(),
-			CIDRs:                &ipamv1alpha1_legacy.CIDRs{},
-			CIDRsList:            &ipamv1alpha1_legacy.CIDRsList{},
-			WatchConfigmapSecrets: watchConfigmapSecrets,
+			Client:             mgr.GetClient(),
+			CIDRs:              &ipamv1alpha1_legacy.CIDRs{},
+			CIDRsList:          &ipamv1alpha1_legacy.CIDRsList{},
+			HTTPHeadersEnabled: httpHeadersEnabled,
 		}).SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "LegacyCIDRs"}
 		}
 		if err := (&CIDRReconciler{
-			Client:               mgr.GetClient(),
-			CIDRs:                &ipamv1alpha1_legacy.ClusterCIDRs{},
-			CIDRsList:            &ipamv1alpha1_legacy.ClusterCIDRsList{},
-			WatchConfigmapSecrets: watchConfigmapSecrets,
+			Client:             mgr.GetClient(),
+			CIDRs:              &ipamv1alpha1_legacy.ClusterCIDRs{},
+			CIDRsList:          &ipamv1alpha1_legacy.ClusterCIDRsList{},
+			HTTPHeadersEnabled: httpHeadersEnabled,
 		}).SetupWithManager(mgr, namePrefix); err != nil {
 			return &setupError{error: err, controllerType: "LegacyClusterCIDRs"}
 		}

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -241,7 +241,7 @@ func TestCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -313,7 +313,7 @@ func TestClusterCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "legacy.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "legacy.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -387,7 +387,7 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))
@@ -482,7 +482,7 @@ func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com"))
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, "legacy.ipam.com/v1alpha1", t.Name(), "ipam.example.com", true))
 
 	go func() {
 		require.NoError(t, mgr.Start(context.Background()))

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -437,6 +437,104 @@ func TestCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 	)
 }
 
+func TestCIDRsControllerDoesNotWatchSecretsAndConfigMapsWhenDisabled(t *testing.T) {
+	extendedScheme, err := controllers.Scheme("")
+	require.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).Build()
+	k8sCache := &testCache{Client: k8sClient, scheme: extendedScheme}
+
+	mgr, err := manager.New(&rest.Config{}, manager.Options{
+		Scheme: extendedScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+			return meta.NewDefaultRESTMapper(extendedScheme.PrioritizedVersionsAllGroups()), nil
+		},
+		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
+			return k8sClient, nil
+		},
+		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+			return k8sCache, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.adevinta.com", false))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		require.NoError(t, mgr.Start(ctx))
+	}()
+
+	require.Eventually(
+		t,
+		func() bool {
+			k8sCache.m.Lock()
+			defer k8sCache.m.Unlock()
+			informer, ok := k8sCache.informers[ipamv1alpha1.GroupVersion.WithKind("CIDRs")]
+			return ok && informer != nil && len(informer.handlers) > 0
+		},
+		5*time.Second,
+		100*time.Millisecond,
+	)
+
+	k8sCache.m.Lock()
+	defer k8sCache.m.Unlock()
+	secretGVK := schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
+	configMapGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+	_, secretWatched := k8sCache.informers[secretGVK]
+	_, configMapWatched := k8sCache.informers[configMapGVK]
+	assert.False(t, secretWatched, "Secret informer must not be registered when watchConfigmapSecrets=false")
+	assert.False(t, configMapWatched, "ConfigMap informer must not be registered when watchConfigmapSecrets=false")
+}
+
+func TestCIDRsControllerWatchesSecretsAndConfigMapsWhenEnabled(t *testing.T) {
+	extendedScheme, err := controllers.Scheme("")
+	require.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).Build()
+	k8sCache := &testCache{Client: k8sClient, scheme: extendedScheme}
+
+	mgr, err := manager.New(&rest.Config{}, manager.Options{
+		Scheme: extendedScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+			return meta.NewDefaultRESTMapper(extendedScheme.PrioritizedVersionsAllGroups()), nil
+		},
+		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
+			return k8sClient, nil
+		},
+		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+			return k8sCache, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, controllers.SetupControllersWithManager(mgr, false, false, false, "", t.Name(), "ipam.adevinta.com", true))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		require.NoError(t, mgr.Start(ctx))
+	}()
+
+	secretGVK := schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
+	configMapGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+
+	require.Eventually(
+		t,
+		func() bool {
+			k8sCache.m.Lock()
+			defer k8sCache.m.Unlock()
+			secret, secretOk := k8sCache.informers[secretGVK]
+			cm, cmOk := k8sCache.informers[configMapGVK]
+			return secretOk && secret != nil && len(secret.handlers) > 0 &&
+				cmOk && cm != nil && len(cm.handlers) > 0
+		},
+		5*time.Second,
+		100*time.Millisecond,
+	)
+}
+
 func TestClusterCIDRsControllerTriggersGatewayReconciliation(t *testing.T) {
 	extendedScheme, err := controllers.Scheme("legacy.ipam.com/v1alpha1")
 	assert.NoError(t, err)

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -484,8 +484,8 @@ func TestCIDRsControllerDoesNotWatchSecretsAndConfigMapsWhenDisabled(t *testing.
 	configMapGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 	_, secretWatched := k8sCache.informers[secretGVK]
 	_, configMapWatched := k8sCache.informers[configMapGVK]
-	assert.False(t, secretWatched, "Secret informer must not be registered when watchConfigmapSecrets=false")
-	assert.False(t, configMapWatched, "ConfigMap informer must not be registered when watchConfigmapSecrets=false")
+	assert.False(t, secretWatched, "Secret informer must not be registered when httpHeadersEnabled=false")
+	assert.False(t, configMapWatched, "ConfigMap informer must not be registered when httpHeadersEnabled=false")
 }
 
 func TestCIDRsControllerWatchesSecretsAndConfigMapsWhenEnabled(t *testing.T) {


### PR DESCRIPTION
* During heavy testing I have noticed that most of time on startup it waste time on configmap and secrets - but we dont even use this feature

* TODO separate feature: narrow down to special labels only ?