### PR TITLE
fix(cidrs): match source events by object name

### DIFF
--- a/pkg/controllers/cidrs_controller.go
+++ b/pkg/controllers/cidrs_controller.go
@@ -536,7 +536,7 @@ func newObjectRefToCIDRsFuncMap(c client.Client, cidrsKind ipamv1alpha1.CIDRsGet
 				if namespace != object.GetNamespace() {
 					continue
 				}
-				if source.SecretRef.Name == objectRef.Name {
+				if object.GetName() == objectRef.Name {
 					requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cidrs)})
 				}
 			}

--- a/pkg/controllers/cidrs_controller_test.go
+++ b/pkg/controllers/cidrs_controller_test.go
@@ -1075,6 +1075,18 @@ func TestObjectRefToCIDRsMapper(t *testing.T) {
 				},
 			)
 		})
+		t.Run("When the secret name does not match the reference", func(t *testing.T) {
+			testCaseObjectRefToCIDRsMapper(
+				t,
+				&ipamv1alpha1.CIDRsList{},
+				[]client.Object{
+					newCIDRBuilder(&ipamv1alpha1.CIDRs{}).withName("cidr-with-secret-ref").withNamespace("secret-namespace").withSecretRef(ipamv1alpha1.ObjectRef{Name: "my-secret"}).build(),
+				},
+				"secret-namespace",
+				"unrelated-secret",
+				[]client.ObjectKey{},
+			)
+		})
 		t.Run("When cidrs are in the other namespaces than the secret", func(t *testing.T) {
 			testCaseObjectRefToCIDRsMapper(
 				t,
@@ -1121,6 +1133,24 @@ func TestObjectRefToCIDRsMapper(t *testing.T) {
 				[]client.ObjectKey{},
 			)
 		})
+	})
+	t.Run("when using a configmap reference", func(t *testing.T) {
+		scheme, err := Scheme("")
+		require.NoError(t, err)
+		cidrs := newCIDRBuilder(&ipamv1alpha1.CIDRs{}).
+			withName("cidr-with-configmap-ref").
+			withNamespace("configmap-namespace").
+			withConfigMapRef(ipamv1alpha1.ObjectRef{Name: "my-configmap"}).
+			build()
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cidrs).Build()
+		mapper := newObjectRefToCIDRsFuncMap(k8sClient, &ipamv1alpha1.CIDRsList{}, configMapSource)
+
+		requests := mapper(context.Background(), &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "configmap-namespace",
+			Name:      "my-configmap",
+		}})
+
+		assert.Equal(t, []reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(cidrs)}}, requests)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix the Secret and ConfigMap event mapper so it compares the watched Kubernetes object name with the reference selected from `headersFrom`.

## How the mapper is supposed to work

`CIDRReconciler` watches Secrets and ConfigMaps because they can provide HTTP headers for a remote CIDR source. A Secret or ConfigMap event cannot be reconciled directly: the mapper must translate that event into requests for the CIDRs or ClusterCIDRs resources that reference it.

A source matches an event only when both parts of its Kubernetes identity match:

```text
reference namespace == event object namespace
reference name      == event object name
```

The namespace comparison was already present. The object-name comparison was not.

## Problem

The mapper previously used:

```go
source.SecretRef.Name == objectRef.Name
```

`objectRef` is selected by the watch-specific callback:

```go
secretSource(headersFrom)    // returns headersFrom.SecretRef
configMapSource(headersFrom) // returns headersFrom.ConfigMapRef
```

The old condition therefore behaved differently for Secret and ConfigMap events, but was incorrect for both.

### Example 1: an unrelated Secret triggered reconciliation

Given this CIDRs resource:

```yaml
apiVersion: ipam.adevinta.com/v1alpha1
kind: CIDRs
metadata:
  name: private-ranges
  namespace: application
spec:
  location:
    uri: https://example.com/cidrs
    headersFrom:
    - secretRef:
        name: cidr-api-token
```

Now assume an unrelated Secret changes in the same namespace:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: database-password
  namespace: application
```

For the Secret watch, `objectRef` is the same `SecretRef` stored in `source`. The old comparison became:

```go
"cidr-api-token" == "cidr-api-token"
```

It never checked `object.GetName()`, which was `database-password`. Because the namespaces matched, the mapper incorrectly enqueued `application/private-ranges`. In a namespace with many CIDRs resources, any Secret update could cause unnecessary remote HTTP requests and status updates for all CIDRs resources having Secret references there.

After this change, the comparison is:

```go
"database-password" == "cidr-api-token"
```

The mapper correctly returns no reconciliation request.

### Example 2: a referenced ConfigMap did not trigger reconciliation

Given:

```yaml
apiVersion: ipam.adevinta.com/v1alpha1
kind: CIDRs
metadata:
  name: public-ranges
  namespace: application
spec:
  location:
    uri: https://example.com/cidrs
    headersFrom:
    - configMapRef:
        name: cidr-api-headers
```

When `application/cidr-api-headers` changed, `objectRef` correctly contained the ConfigMap reference. However, the old expression compared `source.SecretRef.Name` with `source.ConfigMapRef.Name`:

```go
"" == "cidr-api-headers"
```

That evaluated to false, so `application/public-ranges` was not enqueued. Updated HTTP headers would not be used until another event or a configured periodic requeue happened.

After this change, the comparison is:

```go
object.GetName() == objectRef.Name
// "cidr-api-headers" == "cidr-api-headers"
```

The referenced CIDRs resource is enqueued immediately.

### Example 3: both reference types in one entry

If an entry happened to contain both references with the same name, the old ConfigMap comparison could evaluate to true:

```yaml
headersFrom:
- secretRef:
    name: shared-headers
  configMapRef:
    name: shared-headers
```

But even then, it was comparing the two configured references rather than the ConfigMap event. Any ConfigMap in the resolved namespace could pass that condition. The result depended on configuration coincidence, not on the identity of the watched object.

## Change

Replace the reference-to-reference comparison with the event-to-reference comparison:

```diff
-if source.SecretRef.Name == objectRef.Name {
+if object.GetName() == objectRef.Name {
```

Combined with the existing namespace check, the mapper now matches the complete namespaced identity of the watched Secret or ConfigMap. This works for namespaced CIDRs resources as well as ClusterCIDRs resources whose references specify an explicit namespace.

## Behavioral result

| Event | Reference | Before | After |
|---|---|---|---|
| `application/database-password` Secret | `application/cidr-api-token` Secret | Incorrectly enqueued | Ignored |
| `application/cidr-api-token` Secret | `application/cidr-api-token` Secret | Enqueued | Enqueued |
| `application/cidr-api-headers` ConfigMap | `application/cidr-api-headers` ConfigMap | Usually ignored | Enqueued |
| ConfigMap with a different name | `application/cidr-api-headers` ConfigMap | Depended on SecretRef name | Ignored |

## Tests

- Verify an unrelated Secret in the same namespace does not enqueue a CIDRs resource.
- Verify a matching ConfigMap reference does enqueue its CIDRs resource.
- `go test ./...`