### PR TITLE
feat(cidrs): filter HTTP header source watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,8 @@ spec:
   location:
     cel: 'data.prefixes.filter(p, p.service == "EC2" && has(p.ip_prefix)).map(p, p.ip_prefix)' # transform the AWS response into a list of strings using CEL expression
     uri: https://ip-ranges.amazonaws.com/ip-ranges.json # the remote URL responding all IPs
-    headersFrom: # optional: inject CIDRs to the HTTP request (if the request needs to be authenticated)
-      secretRef: # optional: inject all keys
+    headersFrom: # optional: inject headers into the HTTP request (if the request needs to be authenticated)
+    - secretRef: # optional: inject all keys
         name: aws-authentication-headers # all aws-authentication-headers data will be used as http headers in the http request
         namespace: test # optional. For CIDRs, it must match the CIDRs namespace when not empty.
       configMapRef:
@@ -504,6 +504,8 @@ kind: ConfigMap
 metadata:
   name: aws-headers
   namespace: test
+  labels:
+    ipam.adevinta.com/cidr-http-header-source: "true" # required when the source label selector is enabled
 data:
   My-Header: some-value
 ---
@@ -513,9 +515,28 @@ kind: Secret
 metadata:
   name: aws-authentication-headers
   namespace: test
-data:
-  Authentication: $(echo "Bearer $token" | base64)
+  labels:
+    ipam.adevinta.com/cidr-http-header-source: "true" # required when the source label selector is enabled
+stringData:
+  Authentication: Bearer my-token
 ```
+
+#### Filtering HTTP header source watches
+
+By default, the controller watches and caches all Secrets and ConfigMaps so references can be added dynamically. In clusters with many of these resources, restrict both informer caches to explicitly labelled HTTP header sources:
+
+```yaml
+cidrHTTPHeaderSources:
+  labelSelector: "ipam.adevinta.com/cidr-http-header-source=true"
+```
+
+Or use the flag directly:
+
+```text
+--cidr-http-header-source-label-selector=ipam.adevinta.com/cidr-http-header-source=true
+```
+
+The selector is applied by the Kubernetes API server, reducing watch traffic and preventing unrelated Secret data from being stored in the controller cache. When enabled, every Secret and ConfigMap referenced by `headersFrom` must match the selector; otherwise the controller cannot retrieve it and reports the source as missing.
 
 #### Fetching CIDRs from github
 

--- a/cmd/ingress-allowlisting-controller/main.go
+++ b/cmd/ingress-allowlisting-controller/main.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -57,6 +58,7 @@ func main() {
 	var networkPolicySupportEnabled bool
 	var httpRouteSupportEnabled bool
 	var httpRouteLabelSelector string
+	var cidrHTTPHeaderSourceLabelSelector string
 	var as string
 	var annotationPrefix string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -67,6 +69,7 @@ func main() {
 	flag.BoolVar(&networkPolicySupportEnabled, "networkpolicy-support-enabled", false, "Enable networkpolicy support for the controller")
 	flag.BoolVar(&httpRouteSupportEnabled, "httproute-support-enabled", false, "Enable HTTPRoute support for the controller")
 	flag.StringVar(&httpRouteLabelSelector, "httproute-label-selector", "", "Label selector to filter HTTPRoutes watched by the controller (e.g. 'app.kubernetes.io/managed-by=my-team'). Restricts the informer cache at the API server level.")
+	flag.StringVar(&cidrHTTPHeaderSourceLabelSelector, "cidr-http-header-source-label-selector", "", "Label selector to filter Secrets and ConfigMaps used as CIDR HTTP header sources. Restricts the informer cache at the API server level; every referenced source must match.")
 	flag.StringVar(&legacyGroupVersion, "legacy-group-version", "", "Enables coexistence of two CRDS with different groups for CIDR objects.")
 	flag.StringVar(&as, "as", "", "The user to impersonate to run this controller")
 	flag.StringVar(&annotationPrefix, "annotation-prefix", "ipam.adevinta.com", "Enables coexistence of two CRDS with different groups for CIDR objects.")
@@ -98,17 +101,18 @@ func main() {
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: "c72663fe.github.com/adevinta/ingress-allowlisting-controller",
 	}
+	cacheByObject, err := buildCacheByObject(httpRouteSupportEnabled, httpRouteLabelSelector, cidrHTTPHeaderSourceLabelSelector)
+	if err != nil {
+		setupLog.Fatal(err, "invalid cache label selector")
+	}
+	if len(cacheByObject) > 0 {
+		mgrOptions.Cache = cache.Options{ByObject: cacheByObject}
+	}
 	if httpRouteSupportEnabled && httpRouteLabelSelector != "" {
-		selector, err := labels.Parse(httpRouteLabelSelector)
-		if err != nil {
-			setupLog.Fatal(err, "invalid --httproute-label-selector")
-		}
-		mgrOptions.Cache = cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&gatewayApiv1.HTTPRoute{}: {Label: selector},
-			},
-		}
 		setupLog.Infof("HTTPRoute informer cache restricted to label selector: %s", httpRouteLabelSelector)
+	}
+	if cidrHTTPHeaderSourceLabelSelector != "" {
+		setupLog.Infof("Secret and ConfigMap informer caches restricted to CIDR HTTP header source label selector: %s", cidrHTTPHeaderSourceLabelSelector)
 	}
 	mgr, err := ctrl.NewManager(restConfig, mgrOptions)
 	if err != nil {
@@ -124,6 +128,29 @@ func main() {
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Fatal(err, "problem running manager")
 	}
+}
+
+func buildCacheByObject(httpRouteEnabled bool, httpRouteLabelSelector, cidrHTTPHeaderSourceLabelSelector string) (map[client.Object]cache.ByObject, error) {
+	byObject := make(map[client.Object]cache.ByObject)
+
+	if httpRouteEnabled && httpRouteLabelSelector != "" {
+		selector, err := labels.Parse(httpRouteLabelSelector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --httproute-label-selector: %w", err)
+		}
+		byObject[&gatewayApiv1.HTTPRoute{}] = cache.ByObject{Label: selector}
+	}
+
+	if cidrHTTPHeaderSourceLabelSelector != "" {
+		selector, err := labels.Parse(cidrHTTPHeaderSourceLabelSelector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --cidr-http-header-source-label-selector: %w", err)
+		}
+		byObject[&corev1.Secret{}] = cache.ByObject{Label: selector}
+		byObject[&corev1.ConfigMap{}] = cache.ByObject{Label: selector}
+	}
+
+	return byObject, nil
 }
 
 func checkRBAC(restConfig *rest.Config, gatewayEnabled, networkPolicyEnabled, httpRouteEnabled bool, l4Writers writers.L4WriterRegistry, l7Writers writers.L7WriterRegistry) {

--- a/cmd/ingress-allowlisting-controller/main_test.go
+++ b/cmd/ingress-allowlisting-controller/main_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 	"sigs.k8s.io/e2e-framework/support/kind"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
+	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var (
@@ -39,6 +40,51 @@ var (
 	allowListingNamespace = envconf.RandomName("controller", 16)
 	testNamespace         = envconf.RandomName("ingress", 16)
 )
+
+func TestBuildCacheByObject(t *testing.T) {
+	t.Run("returns no restrictions when selectors are disabled", func(t *testing.T) {
+		byObject, err := buildCacheByObject(false, "", "")
+
+		require.NoError(t, err)
+		assert.Empty(t, byObject)
+	})
+
+	t.Run("combines HTTPRoute and CIDR header source selectors", func(t *testing.T) {
+		byObject, err := buildCacheByObject(
+			true,
+			"allowlisting=enabled",
+			"ipam.adevinta.com/cidr-http-header-source=true",
+		)
+
+		require.NoError(t, err)
+		require.Len(t, byObject, 3)
+		for object, config := range byObject {
+			switch object.(type) {
+			case *gatewayApiv1.HTTPRoute:
+				assert.Equal(t, "allowlisting=enabled", config.Label.String())
+			case *v1.Secret, *v1.ConfigMap:
+				assert.Equal(t, "ipam.adevinta.com/cidr-http-header-source=true", config.Label.String())
+			default:
+				t.Fatalf("unexpected cache object type %T", object)
+			}
+		}
+	})
+
+	t.Run("ignores an HTTPRoute selector when HTTPRoute support is disabled", func(t *testing.T) {
+		byObject, err := buildCacheByObject(false, "not a valid selector (", "source=true")
+
+		require.NoError(t, err)
+		assert.Len(t, byObject, 2)
+	})
+
+	t.Run("rejects invalid selectors", func(t *testing.T) {
+		_, err := buildCacheByObject(true, "not a valid selector (", "")
+		assert.ErrorContains(t, err, "--httproute-label-selector")
+
+		_, err = buildCacheByObject(false, "", "not a valid selector (")
+		assert.ErrorContains(t, err, "--cidr-http-header-source-label-selector")
+	})
+}
 
 func testCIDRsStatusIsUpdated(ctx context.Context, t *testing.T, k8sClient client.Client, cidr ipamv1alpha1.CIDRsGetter, expectedCIDRs []string) {
 	t.Helper()

--- a/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
+++ b/helm-chart/ingress-allowlisting-controller/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         - "--httproute-label-selector={{ . }}"
 {{- end }}
 {{- end }}
+{{- with .Values.cidrHTTPHeaderSources.labelSelector }}
+        - "--cidr-http-header-source-label-selector={{ . }}"
+{{- end }}
 {{ with .Values.legacyGroupVersion }}
         - "--legacy-group-version={{ . }}"
 {{- end }}

--- a/helm-chart/ingress-allowlisting-controller/values.yaml
+++ b/helm-chart/ingress-allowlisting-controller/values.yaml
@@ -28,6 +28,9 @@ httproute:
   enabled: false
   labelSelector: ""
 
+cidrHTTPHeaderSources:
+  labelSelector: ""
+
 networkpolicy:
   enabled: false
 


### PR DESCRIPTION
## Summary

Add an optional server-side label selector for Secrets and ConfigMaps used as HTTP header sources by CIDRs and ClusterCIDRs remote fetches.

## Motivation

The CIDR controllers currently start informers for the entire Secret and ConfigMap kinds. As a result, every object of either kind visible to the controller is watched and cached, even though only a small subset may be referenced from `spec.location.headersFrom`. For Secrets in particular, that also means unrelated Secret payloads are retained in the controller cache.

Exact referenced names are dynamic and cannot be represented by a static multi-name informer selector. An opt-in label selector gives operators a stable way to identify the eligible source set while allowing Kubernetes to filter the List/Watch at the API server.

## Change

- Add `--cidr-http-header-source-label-selector`.
- Apply the parsed selector to both `core/v1 Secret` and `core/v1 ConfigMap` through controller-runtime `cache.Options.ByObject`.
- Compose these cache entries with the existing HTTPRoute label selector instead of allowing one cache configuration to replace another.
- Add the Helm value `cidrHTTPHeaderSources.labelSelector`.
- Document the required labeling contract and operational behavior.
- Correct the nearby `headersFrom` example to show its array shape and use valid Secret `stringData`.

The option defaults to empty, so existing installations retain the current watch behavior. When configured, every referenced Secret and ConfigMap must match the selector; an unmatched source is intentionally absent from the cache and is reported as missing during reconciliation.

## Example

```yaml
cidrHTTPHeaderSources:
  labelSelector: ipam.adevinta.com/cidr-http-header-source=true
```

Referenced sources must carry the corresponding label:

```yaml
metadata:
  labels:
    ipam.adevinta.com/cidr-http-header-source: "true"
```

## Scope

This PR only narrows the informer List/Watch and cache. The existing mapper name-comparison defect is intentionally addressed in a separate PR so both changes can be reviewed and released independently.

## Validation

- `go test ./...`
- `go vet ./...`
- `helm lint helm-chart/ingress-allowlisting-controller`
- Rendered the chart with both HTTPRoute and CIDR source selectors and verified both controller arguments are present.