### PR TITLE
feat(optimization): reduce resolution calls

### DIFF
--- a/docs/cidrs.md
+++ b/docs/cidrs.md
@@ -97,3 +97,48 @@ list if needed.
 - Invalid CIDR strings (e.g. `10.0.0` without a mask) are logged as warnings and skipped.
 - If none of the named objects exist, the controller logs a warning and writes a deny-all
   policy (empty source range) to fail safe.
+
+---
+
+## Prefer `ClusterCIDRs` for CIDRs shared across namespaces
+
+If the same IP set is referenced by routes in more than one namespace, use a single `ClusterCIDRs`
+object instead of duplicating `CIDRs` objects per namespace.
+
+The controller caches CIDR resolutions within a single reconcile. When all routes in a merge group
+share the same `cluster-allowlist-group` value, the cluster object is fetched **once** regardless
+of how many namespaces are involved. Namespace-scoped `CIDRs` objects with the same content but
+different namespaces each require an independent lookup and do not benefit from this cache.
+
+**Instead of this:**
+
+```yaml
+apiVersion: ipam.adevinta.com/v1alpha1
+kind: CIDRs
+metadata:
+  name: vpn
+  namespace: ns-team-a
+spec:
+  cidrs: ["10.0.0.0/8"]
+---
+apiVersion: ipam.adevinta.com/v1alpha1
+kind: CIDRs
+metadata:
+  name: vpn
+  namespace: ns-team-b
+spec:
+  cidrs: ["10.0.0.0/8"]
+```
+
+**Prefer this:**
+
+```yaml
+apiVersion: ipam.adevinta.com/v1alpha1
+kind: ClusterCIDRs
+metadata:
+  name: vpn
+spec:
+  cidrs: ["10.0.0.0/8"]
+```
+
+And reference it with `ipam.adevinta.com/cluster-allowlist-group: vpn` on all HTTPRoutes.

--- a/pkg/controllers/httproute_controller.go
+++ b/pkg/controllers/httproute_controller.go
@@ -96,14 +96,24 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	// Resolve CIDRs once — used by all per-route writers (always Traefik, Istio when no mergeKey).
-	allowedIps, cidrErr := r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
-
 	var hostnames []string
 	for _, h := range httproute.Spec.Hostnames {
 		hostnames = append(hostnames, string(h))
 	}
 	granularity := httproute.Annotations[r.granularityAnnotation()]
+
+	// Lazy CIDR resolution: only needed for per-route writers (Traefik always, Istio without mergeKey).
+	// Merge-mode routes (Istio + mergeKey) resolve all siblings' CIDRs inside ApplyMerged, so
+	// resolving the current route here would be wasted work if no per-route writer is present.
+	var allowedIps []string
+	var cidrErr error
+	var cidrResolved bool
+	resolveCIDRs := func() {
+		if !cidrResolved {
+			allowedIps, cidrErr = r.CidrResolver.GetCidrsFromObject(ctx, &httproute)
+			cidrResolved = true
+		}
+	}
 
 	// invokedWriters tracks which writers were used in this reconcile.
 	// Any registered writer not present here had its gateway removed from parentRefs
@@ -149,6 +159,7 @@ func (r *HTTPRouteAllowlistingReconciler) Reconcile(ctx context.Context, req ctr
 		}
 
 		// Per-route apply path — Traefik always, Istio when no mergeKey.
+		resolveCIDRs()
 		if cidrErr == r.CidrResolver.AnnotationNotFoundError() {
 			if err := writer.DeleteForRoute(ctx, r.managedByValue(), httproute.Namespace, httproute.Name); err != nil {
 				return ctrl.Result{}, err

--- a/pkg/controllers/httproute_controller_test.go
+++ b/pkg/controllers/httproute_controller_test.go
@@ -1193,6 +1193,60 @@ func TestReconcileHTTPRouteMergeSameNamespace(t *testing.T) {
 	assert.Equal(t, "my-gateway", policy.Spec.TargetRefs[0].Name)
 }
 
+// TestMergeOnlyRouteDoesNotEagerlyResolveCIDRs verifies that when all parentRefs lead to the
+// Istio merge path, GetCidrsFromObject is NOT called before the loop (eager, wasted resolution).
+//
+// Without the lazy-resolution fix, Reconcile calls GetCidrsFromObject unconditionally at line ~100,
+// then ApplyMerged calls it again for the same route as a sibling — two Gets for the same CIDR.
+// With the fix, the call is deferred: only ApplyMerged fetches it, so exactly one Get occurs.
+func TestMergeOnlyRouteDoesNotEagerlyResolveCIDRs(t *testing.T) {
+	clusterCIDR := &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "globalnet"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"10.0.0.0/8"}},
+	}
+	gwNS := gatewayApiv1.Namespace("gw-ns")
+	route := &gatewayApiv1.HTTPRoute{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "my-svc.example.com", Namespace: "ns",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/cluster-allowlist-group": "globalnet",
+				"ipam.adevinta.com/merge":                   "my-svc",
+			},
+		},
+		Spec: gatewayApiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayApiv1.CommonRouteSpec{ParentRefs: []gatewayApiv1.ParentReference{
+				{Name: "cross-ns-gw", Namespace: &gwNS},
+			}},
+			Hostnames: []gatewayApiv1.Hostname{"my-svc.example.com"},
+		},
+	}
+	gwClass := newIstioGatewayClass("istio")
+	gw := newTestGateway("cross-ns-gw", "gw-ns", "istio")
+
+	var clusterCIDRGetCount int
+	baseClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(clusterCIDR, route, gwClass, gw).Build()
+	counting := &testfunc{
+		WithWatch: baseClient,
+		getfunc: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*ipamv1alpha1.ClusterCIDRs); ok {
+				clusterCIDRGetCount++
+			}
+			return baseClient.Get(ctx, key, obj, opts...)
+		},
+	}
+
+	reconciler := newHTTPRouteReconciler(t, counting, extendedScheme)
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "my-svc.example.com", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	// With lazy resolution: 1 Get — only inside ApplyMerged for the single sibling.
+	// Without the fix: 2 Gets — once eagerly before the parentRef loop, once inside ApplyMerged.
+	assert.Equal(t, 1, clusterCIDRGetCount,
+		"ClusterCIDRs must be fetched exactly once — the eager call before the parentRef loop is wasted for merge-only routes")
+}
+
 func TestReconcileHTTPRouteOwnerReference(t *testing.T) {
 	cidr := &ipamv1alpha1.CIDRs{
 		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},

--- a/pkg/controllers/writers/istio_l7_merge.go
+++ b/pkg/controllers/writers/istio_l7_merge.go
@@ -41,9 +41,37 @@ type mergedTuple struct {
 func (w *IstioL7Writer) ApplyMerged(ctx context.Context, gateway *gatewayApiv1.Gateway, siblings []*gatewayApiv1.HTTPRoute, mergeKey string) error {
 	granularityAnnotation := w.annotationPrefix + "/granularity"
 
+	// Cache CIDR resolutions within this call: siblings sharing identical annotation values
+	// in the same namespace always resolve to the same CIDRs, so there is no need to hit
+	// the Kubernetes API more than once per unique annotation combination.
+	type cidrCacheKey struct{ ns, localAnn, clusterAnn string }
+	cidrCache := map[cidrCacheKey][]string{}
+	resolveCIDRs := func(sibling *gatewayApiv1.HTTPRoute) ([]string, error) {
+		anns := sibling.GetAnnotations()
+		key := cidrCacheKey{
+			localAnn:   anns[w.cidrResolver.Annotation()],
+			clusterAnn: anns[w.cidrResolver.ClusterAnnotation()],
+		}
+		// Namespace only affects resolution of local (namespaced) CIDRs.
+		// When no local annotation is present the result is namespace-independent,
+		// so omit ns from the key to get cache hits across namespaces in the same group.
+		if key.localAnn != "" {
+			key.ns = sibling.Namespace
+		}
+		if cached, ok := cidrCache[key]; ok {
+			return cached, nil
+		}
+		ips, err := w.cidrResolver.GetCidrsFromObject(ctx, sibling)
+		if err != nil {
+			return nil, err
+		}
+		cidrCache[key] = ips
+		return ips, nil
+	}
+
 	var tuples []mergedTuple
 	for _, sibling := range siblings {
-		ips, err := w.cidrResolver.GetCidrsFromObject(ctx, sibling)
+		ips, err := resolveCIDRs(sibling)
 		if err == w.cidrResolver.AnnotationNotFoundError() {
 			continue
 		}

--- a/pkg/controllers/writers/istio_l7_merge_test.go
+++ b/pkg/controllers/writers/istio_l7_merge_test.go
@@ -2,17 +2,43 @@ package writers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayApiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	istioApiSecurityV1 "istio.io/api/security/v1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+
+	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
+	"github.com/adevinta/ingress-allowlisting-controller/pkg/resolvers"
 )
+
+// countingGetClient wraps a client.Client and invokes onGet for every Get call,
+// letting tests assert how many times specific object types are fetched from the API.
+type countingGetClient struct {
+	client.Client
+	onGet func(obj client.Object)
+}
+
+func (c *countingGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.onGet != nil {
+		c.onGet(obj)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func testClusterCIDRs(name string, cidrs ...string) *ipamv1alpha1.ClusterCIDRs {
+	return &ipamv1alpha1.ClusterCIDRs{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: cidrs},
+	}
+}
 
 // allPolicyHosts collects every host across all rules and to-blocks of a policy.
 func allPolicyHosts(p *istiosecurityv1.AuthorizationPolicy) []string {
@@ -299,4 +325,107 @@ func TestMergeTosByPaths_PathOrderIndependent(t *testing.T) {
 	require.Len(t, result, 1, "same paths in different order must compact into one To operation")
 	assert.ElementsMatch(t, []string{"host-a.example.com", "host-b.example.com"}, result[0].Operation.Hosts)
 	assert.ElementsMatch(t, []string{"/api", "/health"}, result[0].Operation.Paths)
+}
+
+// TestApplyMerged_MixedLocalAndClusterCIDRs verifies that two routes in different namespaces,
+// each carrying both a cluster annotation (shared) and a local annotation (namespace-specific),
+// produce two separate Istio Rules — one per unique resolved CIDR set.
+//
+// The resolved CIDR set for each route is the union of its local CIDRs and the shared cluster CIDRs.
+// Because the local CIDRs differ across namespaces, the two union sets are distinct, and the
+// security model requires separate Rules.
+func TestApplyMerged_MixedLocalAndClusterCIDRs(t *testing.T) {
+	clusterCIDR := testClusterCIDRs("global-net", "10.0.0.0/8")
+	localOne := testCIDRs("one", "ns-one", "192.168.1.0/24")
+	localTwo := testCIDRs("two", "ns-two", "192.168.2.0/24")
+
+	routeOne := testRoute("svc-one", "ns-one", "svc-one.example.com")
+	routeOne.Annotations["ipam.adevinta.com/allowlist-group"] = "one"
+	routeOne.Annotations["ipam.adevinta.com/cluster-allowlist-group"] = "global-net"
+
+	routeTwo := testRoute("svc-two", "ns-two", "svc-two.example.com")
+	routeTwo.Annotations["ipam.adevinta.com/allowlist-group"] = "two"
+	routeTwo.Annotations["ipam.adevinta.com/cluster-allowlist-group"] = "global-net"
+
+	gw := testGateway("my-gw", "gw-ns")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).
+		WithObjects(clusterCIDR, localOne, localTwo, routeOne, routeTwo, gw).Build()
+	w := newIstioL7Writer(k8sClient)
+
+	err := w.ApplyMerged(context.Background(), gw, []*gatewayApiv1.HTTPRoute{routeOne, routeTwo}, "shared-service")
+	require.NoError(t, err)
+
+	policy := &istiosecurityv1.AuthorizationPolicy{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "shared-service", Namespace: "gw-ns"}, policy)
+	require.NoError(t, err)
+
+	// Each route resolves to a different CIDR set: cluster + namespace-local.
+	// Different CIDR sets must NOT share a `from` block → two Rules.
+	require.Len(t, policy.Spec.Rules, 2,
+		"routes with different local CIDRs must produce separate Rules even if they share a cluster annotation")
+
+	// Build a map from host → CIDRs for deterministic assertions.
+	hostToCIDRs := map[string][]string{}
+	for _, rule := range policy.Spec.Rules {
+		cidrs := rule.From[0].Source.RemoteIpBlocks
+		for _, to := range rule.To {
+			for _, h := range to.Operation.Hosts {
+				hostToCIDRs[h] = cidrs
+			}
+		}
+	}
+
+	assert.ElementsMatch(t, []string{"10.0.0.0/8", "192.168.1.0/24"}, hostToCIDRs["svc-one.example.com"],
+		"svc-one must be allowed from global-net + its own local CIDR")
+	assert.ElementsMatch(t, []string{"10.0.0.0/8", "192.168.2.0/24"}, hostToCIDRs["svc-two.example.com"],
+		"svc-two must be allowed from global-net + its own local CIDR")
+}
+
+// TestApplyMerged_CacheDeduplicatesResolutionsAcrossNamespaces verifies that ApplyMerged
+// resolves CIDRs exactly once when all siblings share the same cluster annotation value,
+// even when they are spread across different namespaces.
+//
+// Without the within-call cache (with namespace-ignoring key for cluster-only annotations),
+// each sibling triggers an independent GetCidrsFromObject call — one Get per sibling.
+// With the cache: the first sibling populates it; the rest are cache hits — one Get total.
+func TestApplyMerged_CacheDeduplicatesResolutionsAcrossNamespaces(t *testing.T) {
+	const siblingCount = 5
+	sharedCIDR := testClusterCIDRs("shared-vpn", "10.0.0.0/8")
+	gw := testGateway("my-gw", "gw-ns")
+
+	var siblings []*gatewayApiv1.HTTPRoute
+	objs := []client.Object{sharedCIDR, gw}
+	for i := 0; i < siblingCount; i++ {
+		r := testRoute(
+			fmt.Sprintf("svc.ns-%d.example.com", i),
+			fmt.Sprintf("ns-%d", i),
+			fmt.Sprintf("svc.ns-%d.example.com", i),
+		)
+		r.Annotations["ipam.adevinta.com/cluster-allowlist-group"] = "shared-vpn"
+		siblings = append(siblings, r)
+		objs = append(objs, r)
+	}
+
+	var clusterCIDRGetCount int
+	baseClient := fake.NewClientBuilder().WithScheme(istioL7Scheme).WithObjects(objs...).Build()
+	counting := &countingGetClient{
+		Client: baseClient,
+		onGet: func(obj client.Object) {
+			if _, ok := obj.(*ipamv1alpha1.ClusterCIDRs); ok {
+				clusterCIDRGetCount++
+			}
+		},
+	}
+	resolver := resolvers.CidrResolver{Client: counting, AnnotationPrefix: resolvers.DefaultPrefix}
+	w := NewIstioL7Writer(counting, "ingress-allowlisting-controller", resolver)
+
+	err := w.ApplyMerged(context.Background(), gw, siblings, "my-service")
+	require.NoError(t, err)
+
+	// With the cache: 1 Get — all siblings share the same cluster annotation, namespace
+	// is excluded from the cache key for cluster-only annotations.
+	// Without the cache fix: 5 Gets — one per sibling due to per-namespace cache keys.
+	assert.Equal(t, 1, clusterCIDRGetCount,
+		"ClusterCIDRs must be fetched once across %d siblings with identical cluster annotations", siblingCount)
 }


### PR DESCRIPTION
CIDR resolution call reduction per fix

  ### Layer 1 — lazy resolution (`httproute_controller.go`)

  Scenario: one merge-only HTTPRoute reconciled (Istio + `mergeKey` annotation, cluster CIDR only).

  | | `GetCidrsFromObject` calls per reconcile |
  |---|---|
  | Before fix | **2** - once eagerly before the parentRef loop, once inside `ApplyMerged` |
  | After fix | **1** - only inside `ApplyMerged` (lazy closure, skipped for merge path) |

  ---

  ### Layer 2 - within-call cache (`istio_l7_merge.go`)

  Scenario: N siblings in different namespaces, all sharing the same cluster annotation.

  | | `GetCidrsFromObject` calls per `ApplyMerged` invocation |
  |---|---|
  | Before fix | **N** - one per sibling (no cache; namespace in key caused misses across namespaces) |
  | After fix | **1** - first sibling populates cache; rest are hits (namespace excluded from key for cluster-only annotations) |

  Test uses N = 5; live system had groups of 11+ siblings.

  ---

  ### Combined - live system measurement (25-second window)

  | | Total `"resolving allowlist name"` log lines |
  |---|---|
  | Before both fixes | **3,625** |
  | After both fixes | **629** |
  | Reduction | **~5×** |