### PR TITLE
feat(optimization): skip Update when allowlist is unchanged to break reconcile loop

### DIFF
--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -254,6 +254,7 @@ func TestCIDRsControllerTriggersIngressReconciliation(t *testing.T) {
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			return k8sCache, nil
 		},
+		Metrics: metricsserver.Options{BindAddress: "0"},
 	})
 	require.NoError(t, err)
 	require.NoError(t, controllers.SetupControllersWithManager(mgr, true, false, false, false, "", t.Name(), "ipam.example.com", true))

--- a/pkg/controllers/ingress_controller.go
+++ b/pkg/controllers/ingress_controller.go
@@ -49,6 +49,9 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	log.Infof("Ingress %s being reconciled. Creating/updating allowlist...", ingressMetadata.GetName())
 
+	const whitelistAnnotation = "nginx.ingress.kubernetes.io/whitelist-source-range"
+	originalWhitelist := netV1Ingress.Annotations[whitelistAnnotation]
+
 	updatedIngress, err := r.reconcileIngress(ctx, netV1Ingress)
 	if err != nil {
 		if err == r.CidrResolver.AnnotationNotFoundError() {
@@ -56,6 +59,10 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		log.Error(err, "Error creating or updating allowlist")
 		return ctrl.Result{}, err
+	}
+
+	if originalWhitelist == updatedIngress.Annotations[whitelistAnnotation] {
+		return ctrl.Result{}, nil
 	}
 
 	netV1Ingress.Annotations = updatedIngress.Annotations

--- a/pkg/controllers/ingress_controller_test.go
+++ b/pkg/controllers/ingress_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -494,6 +496,32 @@ func TestCidrToIngressMapper(t *testing.T) {
 		assert.Len(t, requests, 1)
 		assert.Equal(t, requests[0].Name, "test2")
 	})
+}
+
+func TestReconcileIngressSkipsUpdateWhenUnchanged(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16"}},
+	}
+	ingress := &netv1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "mynamespace",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group":                  "localnet",
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "192.168.0.0/16",
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, ingress).Build()
+	reconciler := &IngressReconciler{Client: k8sClient, CidrResolver: resolvers.CidrResolver{Client: k8sClient, AnnotationPrefix: resolvers.DefaultPrefix}}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "mynamespace", Name: "test"}})
+	assert.NoError(t, err)
+
+	updated := &netv1.Ingress{}
+	assert.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Namespace: "mynamespace", Name: "test"}, updated))
+	assert.Equal(t, "999", updated.ResourceVersion, "Update should not have been called when annotation is already correct")
 }
 
 func TestClusterCidrToIngressMapper(t *testing.T) {

--- a/pkg/controllers/networkpolicy_controller.go
+++ b/pkg/controllers/networkpolicy_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 
 	netv1 "k8s.io/api/networking/v1"
@@ -61,6 +62,10 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		log.Error(err, "Error creating or updating networkpolicy")
 		return ctrl.Result{}, err
+	}
+
+	if reflect.DeepEqual(networkpolicy.Spec, updatedNetworkPolicy.Spec) {
+		return ctrl.Result{}, nil
 	}
 
 	networkpolicy = updatedNetworkPolicy

--- a/pkg/controllers/networkpolicy_controller_test.go
+++ b/pkg/controllers/networkpolicy_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ipamv1alpha1 "github.com/adevinta/ingress-allowlisting-controller/pkg/apis/ipam.adevinta.com/v1alpha1"
@@ -13,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -720,4 +722,35 @@ func TestClusterCidrToNetworkPoliciesMapper(t *testing.T) {
 		assert.True(t, names["test1"])
 		assert.True(t, names["test2"])
 	})
+}
+
+func TestReconcileNetworkPolicySkipsUpdateWhenUnchanged(t *testing.T) {
+	localnetCidrs := &ipamv1alpha1.CIDRs{
+		ObjectMeta: v1.ObjectMeta{Name: "localnet", Namespace: "mynamespace"},
+		Status:     ipamv1alpha1.CIDRsStatus{CIDRs: []string{"192.168.0.0/16"}},
+	}
+	networkPolicy := &netv1.NetworkPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "mynamespace",
+			Annotations: map[string]string{
+				"ipam.adevinta.com/allowlist-group": "localnet",
+			},
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress},
+			Egress: []netv1.NetworkPolicyEgressRule{
+				{To: []netv1.NetworkPolicyPeer{{IPBlock: &netv1.IPBlock{CIDR: "192.168.0.0/16"}}}},
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(extendedScheme).WithObjects(localnetCidrs, networkPolicy).Build()
+	reconciler := newNetworkPolicyReconciler(t, k8sClient)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "mynamespace", Name: "test-policy"}})
+	assert.NoError(t, err)
+
+	updated := &netv1.NetworkPolicy{}
+	assert.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Namespace: "mynamespace", Name: "test-policy"}, updated))
+	assert.Equal(t, "999", updated.ResourceVersion, "Update should not have been called when spec is already correct")
 }


### PR DESCRIPTION
Only related to self changing kinds (`kind: Ingress`, `kind: Networkpolicy`)

`For(&netv1.Ingress{})` and `For(&netv1.NetworkPolicy{})` watch all object changes, including writes made by this controller. Without a guard, every Update triggers a new watch event → re-enqueue → identical Update → watch event → ..., creating a perpetual low-frequency reconcile loop on every managed object.

Add a pre-Update diff check: compare the current annotation/spec against the computed value before calling client.Update. When nothing changed, skip the write entirely. This breaks the feedback loop after one no-op reconcile, reducing each real change to a single write and eliminating the continuous background churn on unchanged objects.

Before fix, in best scenario, you see update twice. Second call should not provide changes, breaking the loop.

After fix, it reduces update calls by half.

As a bonus, on controller restart (when all watched objects are re-enqueued) objects whose allowlist didn't change during downtime are now handled with zero writes instead of O(N) unnecessary updates.